### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server for the [Local Falcon API](https://www.localfalcon.com/), implemented in TypeScript, using the official MCP SDK. This server exposes Local Falcon reporting capabilities as MCP tools, enabling integration with agentic AI systems and workflows.
 
+<a href="https://glama.ai/mcp/servers/@local-falcon/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@local-falcon/mcp/badge" alt="Local Falcon Server MCP server" />
+</a>
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [Local Falcon MCP Server](https://glama.ai/mcp/servers/@local-falcon/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@local-falcon/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@local-falcon/mcp/badge" alt="Local Falcon Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.