### PR TITLE
Fix bugs, add fieldmask support, session auto-recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dist
 
 
 .DS_Store
+_spec/
+nul

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,250 @@
+# CLAUDE.md — @local-falcon/mcp
+
+## Project Overview
+
+This is the **Local Falcon MCP Server** (`@local-falcon/mcp`), a Model Context Protocol server that wraps the [Local Falcon API](https://docs.localfalcon.com). It enables AI agents to run geo-grid rank tracking scans, retrieve reports, manage campaigns, monitor Google Business Profiles, and analyze competitive positioning across Google Maps, Apple Maps, and AI search platforms.
+
+**Package:** `@local-falcon/mcp` (npm)
+**License:** MIT
+**Runtime:** Node.js / Bun
+**Language:** TypeScript (strict mode)
+
+## Architecture
+
+```
+index.ts          → Entry point. Transport selection (STDIO, SSE, HTTP), session management, OAuth 2.1
+server.ts         → MCP tool registrations. Exports getServer() which creates McpServer with 37 tools
+localfalcon.ts    → API client layer. All fetch functions, rate limiting, retry logic, timeout handling
+oauth/            → OAuth 2.1 authorization server (routes, provider, config, state/client stores)
+```
+
+### Key Design Patterns
+
+- **`server.ts`** exports a single `getServer(sessionMapping)` function that creates and returns an `McpServer` instance with all 37 tools registered via `server.tool(name, description, zodSchema, handler)`.
+- **`localfalcon.ts`** contains one exported function per API endpoint. Two call patterns:
+  - **URL params (v1):** `new URL(endpoint)` → `url.searchParams.set()` → POST with JSON headers
+  - **FormData (v2):** `new FormData()` → `form.append()` → POST with form body
+- **API key resolution:** `getApiKey(ctx)` checks the session mapping first (for OAuth-authenticated remote sessions), then falls back to `process.env.LOCAL_FALCON_API_KEY` (for STDIO/local use).
+- **`handleNullOrUndefined()`** converts null/undefined Zod outputs to empty strings before passing to API client functions. The API client functions then use `if (value)` guards to skip empty params.
+
+### Infrastructure (localfalcon.ts)
+
+| Component | Details |
+|---|---|
+| Rate Limiter | Sliding window, 5 requests per 1000ms |
+| Retry | Exponential backoff, 3 retries, 1s initial delay. Retries on network errors, timeouts, 5xx responses |
+| Timeout | 30s default (`DEFAULT_TIMEOUT_MS`), 60s for long operations (`LONG_OPERATION_TIMEOUT_MS`) |
+| JSON Parsing | `safeParseJson()` helper with error logging |
+
+### Transport Modes
+
+Started via CLI argument to `index.ts`:
+
+| Mode | Command | Description |
+|---|---|---|
+| `stdio` (default) | `bun run index.ts` or `bun run index.ts stdio` | Standard I/O for local MCP clients |
+| `sse` | `bun run index.ts sse` | Server-Sent Events, OAuth 2.1 protected |
+| `http` | `bun run index.ts http` | Streamable HTTP, OAuth 2.1 protected |
+| `HTTPAndSSE` | `bun run index.ts HTTPAndSSE` | Both HTTP and SSE on same server |
+
+Remote modes (SSE, HTTP) use OAuth 2.1 with PKCE for authentication. The server implements RFC 8414 (Authorization Server Metadata), RFC 9728 (Protected Resource Metadata), and RFC 7591 (Dynamic Client Registration).
+
+## Tool Inventory
+
+### Reports — List & Retrieve (20 tools, all support `fieldmask`)
+
+| Tool | Description |
+|---|---|
+| `listLocalFalconScanReports` | List scan reports. Filter by placeId, keyword, platform, gridSize, date range, campaignKey |
+| `getLocalFalconReport` | Get a specific scan report by report_key |
+| `listLocalFalconTrendReports` | List trend reports. Filter by placeId, keyword, platform, date range |
+| `getLocalFalconTrendReport` | Get a specific trend report by report_key |
+| `listLocalFalconLocationReports` | List location reports. Filter by placeId, keyword, date range |
+| `getLocalFalconLocationReport` | Get a specific location report by report_key |
+| `listLocalFalconKeywordReports` | List keyword reports. Filter by keyword, date range |
+| `getLocalFalconKeywordReport` | Get a specific keyword report by report_key |
+| `getLocalFalconCompetitorReports` | List competitor reports. Filter by placeId, keyword, gridSize, date range |
+| `getLocalFalconCompetitorReport` | Get a specific competitor report by report_key |
+| `listLocalFalconCampaignReports` | List campaign reports. Filter by placeId, date range, runDate |
+| `getLocalFalconCampaignReport` | Get a specific campaign report by report_key, optional run date |
+| `listLocalFalconGuardReports` | List Falcon Guard reports. Filter by status, date range |
+| `getLocalFalconGuardReport` | Get a specific guard report by placeId, optional date range |
+| `listLocalFalconReviewsAnalysisReports` | List reviews analysis reports. Filter by placeId, frequency, reviewsKey |
+| `getLocalFalconReviewsAnalysisReport` | Get a specific reviews analysis report by report_key |
+| `listAllLocalFalconLocations` | List all saved locations in the account. Filter by query |
+| `getLocalFalconGoogleBusinessLocations` | Search Google for business listings by query, optional near filter |
+| `listLocalFalconAutoScans` | List individually scheduled auto-scans. Filter by placeId, keyword, gridSize, frequency, status, platform |
+| `viewLocalFalconAccountInformation` | Get account info (user, credits, subscription). Optional returnField filter |
+
+### Actions (17 tools, no fieldmask)
+
+| Tool | Description |
+|---|---|
+| `runLocalFalconScan` | Run a new geo-grid scan (costs credits) |
+| `createLocalFalconCampaign` | Create a scheduled campaign |
+| `runLocalFalconCampaign` | Manually trigger a campaign run (costs credits) |
+| `pauseLocalFalconCampaign` | Pause a campaign schedule |
+| `resumeLocalFalconCampaign` | Resume a paused/deactivated campaign |
+| `reactivateLocalFalconCampaign` | Reactivate a campaign deactivated for insufficient credits |
+| `addLocationsToFalconGuard` | Add location(s) to Falcon Guard monitoring |
+| `pauseFalconGuardProtection` | Pause Guard monitoring for location(s) |
+| `resumeFalconGuardProtection` | Resume Guard monitoring for location(s) |
+| `removeFalconGuardProtection` | Remove location(s) from Guard entirely |
+| `searchForLocalFalconBusinessLocation` | Search for businesses on Google or Apple Maps |
+| `saveLocalFalconBusinessLocationToAccount` | Save a business to the Local Falcon account |
+| `getLocalFalconGrid` | Generate grid coordinates for manual single-point checks |
+| `getLocalFalconRankingAtCoordinate` | Check ranking at a single coordinate |
+| `getLocalFalconKeywordAtCoordinate` | Get raw SERP data at a single coordinate |
+| `searchLocalFalconKnowledgeBase` | Search the help/docs knowledge base |
+| `getLocalFalconKnowledgeBaseArticle` | Get full content of a knowledge base article |
+
+## Valid Enum Values
+
+All enum values are validated via Zod schemas in `server.ts`.
+
+### Platform
+
+**`runLocalFalconScan`:**
+`google`, `apple`, `gaio`, `chatgpt`, `gemini`, `grok`, `aimode`, `giao`
+
+**Filter/list tools (`listLocalFalconScanReports`, `listLocalFalconTrendReports`, `listLocalFalconAutoScans`):**
+`google`, `apple`, `gaio`, `chatgpt`, `gemini`, `grok`
+
+**`searchForLocalFalconBusinessLocation`:**
+`google`, `apple`
+
+### Grid Size
+
+**`runLocalFalconScan`:**
+`3`, `5`, `7`, `9`, `11`, `13`, `15`
+
+**Filter/list tools (`listLocalFalconScanReports`, `listLocalFalconAutoScans`) and `createLocalFalconCampaign`:**
+`3`, `5`, `7`, `9`, `11`, `13`, `15`, `17`, `19`, `21`
+
+**`getLocalFalconCompetitorReports`:**
+`3`, `5`, `7`, `9`, `11`, `13`, `15`
+
+### Measurement
+`mi`, `km`
+
+### Frequency (campaigns and auto-scans)
+`one-time`, `daily`, `weekly`, `biweekly`, `monthly`
+
+### Reviews Analysis Frequency
+`one_time`, `daily`, `weekly`, `two_weeks`, `three_weeks`, `four_weeks`, `monthly`
+
+### Guard Report Status
+`protected`, `paused`
+
+### Account Return Field
+`user`, `credit package`, `subscription`, `credits`
+
+## Fieldmask Support
+
+All 20 get/list tools accept an optional `fieldmask` parameter — a comma-separated string of field names to return from the API.
+
+### Syntax
+- Dot notation for nested fields: `location.name`, `statistics.metrics.primaryBusiness`
+- Wildcards for arrays: `scans.*.arp`, `businesses.*.name`
+- Passed to the API as either a URL query parameter (`fieldmask=...`) or a FormData field (`fieldmask`), depending on the endpoint pattern
+
+### Implementation
+In `server.ts`, the `fieldmask` parameter is defined as `z.string().nullish()` on every get/list tool schema. It is passed through `handleNullOrUndefined()` to the corresponding `localfalcon.ts` function, which appends it to the request only when non-empty.
+
+## Parameter Naming Conventions
+
+Parameters use **camelCase** in the Zod schemas (server.ts) and are converted to **snake_case** when sent to the API (localfalcon.ts):
+
+| Server (camelCase) | API (snake_case) |
+|---|---|
+| `placeId` | `place_id` |
+| `reportKey` | `report_key` |
+| `campaignKey` | `campaign_key` |
+| `gridSize` | `grid_size` |
+| `startDate` | `start_date` |
+| `endDate` | `end_date` |
+| `nextToken` | `next_token` |
+| `aiAnalysis` | `ai_analysis` |
+| `reviewsKey` | `reviews_key` |
+| `guardKey` | `guard_key` |
+| `returnField` | `return` |
+| `runDate` | `run` |
+
+## API Versions
+
+The Local Falcon API has two base URLs used by `localfalcon.ts`:
+
+- **v1** (`https://api.localfalcon.com/v1`): Reports, trend reports, keyword reports, location reports, competitor reports, campaign list/detail, guard list/detail, grid, result, search, places, reviews, knowledge base
+- **v2** (`https://api.localfalcon.com/v2`): Run scan, locations search/add, guard add/pause/resume/delete, campaigns create/run/pause/resume/reactivate, account, knowledge base
+
+Public API documentation: [docs.localfalcon.com](https://docs.localfalcon.com)
+
+## Development
+
+### Prerequisites
+- Node.js 18+ or Bun
+- TypeScript 5.8+
+
+### Setup
+```bash
+npm install        # or: bun install
+cp .env.example .env.local
+# Add your LOCAL_FALCON_API_KEY to .env.local
+```
+
+### Build & Type Check
+```bash
+npx tsc --noEmit         # Type check only (strict mode, zero warnings expected)
+npm run build             # Build to dist/ (uses --noCheck for speed)
+```
+
+### Run
+```bash
+npm run start             # STDIO mode (default)
+npm run start:sse         # SSE mode with OAuth
+npm run start:http        # HTTP mode with OAuth
+npm run start:HTTPAndSSE  # Both SSE and HTTP
+```
+
+### Inspect
+```bash
+npm run inspector         # Launch MCP Inspector UI
+```
+
+### Docker
+```bash
+npm run docker:build
+npm run docker:run
+```
+
+### TypeScript Configuration
+- Target: ES2022
+- Module: NodeNext
+- Strict mode enabled
+- Output: `./dist`
+
+## Project Constants
+
+| Constant | Value | Location |
+|---|---|---|
+| `DEFAULT_LIMIT` | `"10"` | server.ts — default page size for list endpoints |
+| `DEFAULT_TIMEOUT_MS` | `30000` | localfalcon.ts |
+| `LONG_OPERATION_TIMEOUT_MS` | `60000` | localfalcon.ts |
+| `MAX_RETRIES` | `3` | localfalcon.ts |
+| `INITIAL_RETRY_DELAY_MS` | `1000` | localfalcon.ts |
+| `RATE_LIMIT_MAX_REQUESTS` | `5` | localfalcon.ts |
+| `RATE_LIMIT_WINDOW_MS` | `1000` | localfalcon.ts |
+
+## File Reference
+
+| File | Purpose |
+|---|---|
+| `index.ts` | Entry point — transport selection, session management, Express app, OAuth routes |
+| `server.ts` | MCP server factory — `getServer()` with all 37 tool registrations |
+| `localfalcon.ts` | API client — fetch functions, rate limiter, retry logic, types |
+| `oauth/` | OAuth 2.1 implementation (authorization, tokens, PKCE, client registration) |
+| `package.json` | Package config, scripts, dependencies |
+| `tsconfig.json` | TypeScript compiler configuration |
+| `.env.example` | Environment variable template |
+| `Dockerfile` | Container build configuration |
+| `_spec/` | Internal development specs (gitignored, not published) |

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -1949,3 +1949,74 @@ export async function fetchLocalFalconReviewsAnalysisReport(
     throw error;
   }
 }
+
+/**
+ * Searches the Local Falcon Knowledge Base for help articles, how-to guides, and platform documentation.
+ * @param {string} apiKey - Your Local Falcon API key
+ * @param {string} [q] - Optional search query to filter articles
+ * @param {string} [categoryId] - Optional category ID to filter articles
+ * @param {string} [limit] - Optional limit for number of results
+ * @param {string} [nextToken] - Optional pagination token for additional results
+ * @returns {Promise<any>} API response with matching knowledge base articles
+ */
+export async function searchLocalFalconKnowledgeBase(
+  apiKey: string,
+  q?: string,
+  categoryId?: string,
+  limit?: string,
+  nextToken?: string
+): Promise<any> {
+  const url = new URL(`${API_BASE_V2}/knowledge-base/`);
+  url.searchParams.set("api_key", apiKey);
+
+  if (q) url.searchParams.set("q", q);
+  if (categoryId) url.searchParams.set("category_id", categoryId);
+  if (limit) url.searchParams.set("limit", limit);
+  if (nextToken) url.searchParams.set("next_token", nextToken);
+
+  await rateLimiter.waitForAvailableSlot();
+
+  return withRetry(async () => {
+    const res = await fetchWithTimeout(url.toString(), {
+      method: "GET",
+      headers: HEADERS,
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+    }
+
+    return await safeParseJson(res);
+  });
+}
+
+/**
+ * Retrieves a specific Local Falcon Knowledge Base article by ID.
+ * @param {string} apiKey - Your Local Falcon API key
+ * @param {string} articleId - The numeric ID of the article to retrieve
+ * @returns {Promise<any>} API response with the full article content
+ */
+export async function getLocalFalconKnowledgeBaseArticle(
+  apiKey: string,
+  articleId: string
+): Promise<any> {
+  const url = new URL(`${API_BASE_V2}/knowledge-base/${articleId}`);
+  url.searchParams.set("api_key", apiKey);
+
+  await rateLimiter.waitForAvailableSlot();
+
+  return withRetry(async () => {
+    const res = await fetchWithTimeout(url.toString(), {
+      method: "GET",
+      headers: HEADERS,
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+    }
+
+    return await safeParseJson(res);
+  });
+}

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -534,21 +534,7 @@ export async function fetchLocalFalconReport(apiKey: string, reportKey: string) 
         throw new Error('Invalid response format from Local Falcon API');
       }
 
-      const report = data.data;
-      return {
-        report_key: report.report_key,
-        timestamp: report.timestamp,
-        date: report.date,
-        place_id: report.place_id,
-        location: report.location,
-        keyword: report.keyword,
-        lat: report.lat,
-        lng: report.lng,
-        grid_size: report.grid_size,
-        radius: report.radius,
-        measurement: report.measurement,
-        ai_analysis: report.ai_analysis,
-      };
+      return data.data;
     } catch (err) {
       throw new Error(`Failed to parse report data: ${err}`);
     }
@@ -1052,12 +1038,9 @@ export async function fetchLocalFalconCompetitorReport(apiKey: string, reportKey
       radius: data.data.radius,
       measurement: data.data.measurement,
       businesses: data.data.businesses.slice(0, limit).map((business: any) => {
-        // Remove unnecessary fields to save bandwidth
         const {
           data_points,
           url,
-          lat,
-          lng,
           claimed,
           display_url,
           platform,
@@ -1116,15 +1099,9 @@ export async function fetchLocalFalconCampaignReports(apiKey: string, limit: str
     return {
       ...data.data,
       reports: data.data.reports.slice(0, limitNum).map((report: any) => {
-        // Remove unnecessary fields to save bandwidth
+        // Remove only truly unnecessary fields
         const {
           data_points,
-          locations,
-          keywords,
-          scans,
-          frequency,
-          last_run,
-          status,
           ...cleanReport
         } = report;
         return cleanReport;
@@ -1208,16 +1185,7 @@ export async function fetchLocalFalconGuardReports(apiKey: string, limit: string
 
     return {
       ...data.data,
-      reports: data.data.reports.slice(0, limitNum).map((report: any) => {
-        // Remove unnecessary fields to save bandwidth
-        const {
-          date_last,
-          date_next,
-          status,
-          ...cleanReport
-        } = report;
-        return cleanReport;
-      })
+      reports: data.data.reports.slice(0, limitNum)
     };
   });
 }

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -541,7 +541,9 @@ export async function fetchLocalFalconReport(apiKey: string, reportKey: string, 
         throw new Error('Invalid response format from Local Falcon API');
       }
 
-      return data.data;
+      // Strip data_points — too large for LLM context windows (e.g. 81 grid points × 20 results each)
+      const { data_points, ...cleanData } = data.data;
+      return cleanData;
     } catch (err) {
       throw new Error(`Failed to parse report data: ${err}`);
     }

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -253,7 +253,7 @@ async function safeParseJson(response: any) {
  * @param {string} endDate - Optional end date to filter reports (format: YYYY-MM-DD)
  * @returns {Promise<LocalFalconReportsResponse>} API response
  */
-export async function fetchLocalFalconReports(apiKey: string, limit: string, nextToken?: string, startDate?: string, endDate?: string, placeId?: string, keyword?: string, gridSize?: string, campaignKey?: string, platform?: string) {
+export async function fetchLocalFalconReports(apiKey: string, limit: string, nextToken?: string, startDate?: string, endDate?: string, placeId?: string, keyword?: string, gridSize?: string, campaignKey?: string, platform?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/reports`);
   url.searchParams.set("api_key", apiKey);
   url.searchParams.set("limit", limit);
@@ -261,10 +261,11 @@ export async function fetchLocalFalconReports(apiKey: string, limit: string, nex
   if (startDate) url.searchParams.set("start_date", startDate);
   if (endDate) url.searchParams.set("end_date", endDate);
   if (placeId) url.searchParams.set("place_id", placeId);
-  if (keyword) url.searchParams.set("keyword", keyword); 
+  if (keyword) url.searchParams.set("keyword", keyword);
   if (gridSize) url.searchParams.set("grid_size", gridSize);
   if (campaignKey) url.searchParams.set("campaign_key", campaignKey);
   if (platform) url.searchParams.set("platform", platform);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -302,7 +303,7 @@ export async function fetchLocalFalconReports(apiKey: string, limit: string, nex
  * @param {string} keyword - Optional keyword to filter by
  * @returns {Promise<LocalFalconTrendReportsResponse>} API response
  */
-export async function fetchLocalFalconTrendReports(apiKey: string, limit: string, nextToken?: string, placeId?: string, keyword?: string, startDate?: string, endDate?: string, platform?: string ) {
+export async function fetchLocalFalconTrendReports(apiKey: string, limit: string, nextToken?: string, placeId?: string, keyword?: string, startDate?: string, endDate?: string, platform?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/trend-reports`);
   url.searchParams.set("api_key", apiKey);
   url.searchParams.set("limit", limit);
@@ -311,7 +312,8 @@ export async function fetchLocalFalconTrendReports(apiKey: string, limit: string
   if (keyword) url.searchParams.set("keyword", keyword);
   if (startDate) url.searchParams.set("start_date", startDate);
   if (endDate) url.searchParams.set("end_date", endDate);
-  if (platform) url.searchParams.set("platform", platform);  
+  if (platform) url.searchParams.set("platform", platform);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -351,7 +353,7 @@ export async function fetchLocalFalconTrendReports(apiKey: string, limit: string
  * @param {string} status - Optional status filter
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconAutoScans(apiKey: string, nextToken?: string, placeId?: string, keyword?: string, grid_size?: string, frequency?: string, status?: string, platform?: string) {
+export async function fetchLocalFalconAutoScans(apiKey: string, nextToken?: string, placeId?: string, keyword?: string, grid_size?: string, frequency?: string, status?: string, platform?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/autoscans`);
   url.searchParams.set("api_key", apiKey);
 
@@ -362,6 +364,7 @@ export async function fetchLocalFalconAutoScans(apiKey: string, nextToken?: stri
   if (frequency) url.searchParams.set("frequency", frequency);
   if (status) url.searchParams.set("status", status);
   if (platform) url.searchParams.set("platform", platform);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -389,7 +392,7 @@ export async function fetchLocalFalconAutoScans(apiKey: string, nextToken?: stri
  * @param {string} nextToken - Optional pagination token
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconLocationReports(apiKey: string, limit: string, placeId?: string, keyword?: string, startDate?:string, endDate?: string, nextToken?: string) {
+export async function fetchLocalFalconLocationReports(apiKey: string, limit: string, placeId?: string, keyword?: string, startDate?:string, endDate?: string, nextToken?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/location-reports`);
   url.searchParams.set("api_key", apiKey);
   url.searchParams.set("limit", limit);
@@ -397,8 +400,9 @@ export async function fetchLocalFalconLocationReports(apiKey: string, limit: str
   if (placeId) url.searchParams.set("place_id", placeId);
   if (keyword) url.searchParams.set("keyword", keyword);
   if (startDate) url.searchParams.set("start_date", startDate);
-  if (endDate) url.searchParams.set("end_date", endDate); 
+  if (endDate) url.searchParams.set("end_date", endDate);
   if (nextToken) url.searchParams.set("next_token", nextToken);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -448,11 +452,12 @@ export async function fetchLocalFalconLocationReports(apiKey: string, limit: str
  * @param {string} query - Optional search query
  * @returns {Promise<any>} API response
  */
-export async function fetchAllLocalFalconLocations(apiKey: string, query?: string) {
+export async function fetchAllLocalFalconLocations(apiKey: string, query?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/locations`);
   url.searchParams.set("api_key", apiKey);
 
   if (query) url.searchParams.set("query", query);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -477,9 +482,10 @@ export async function fetchAllLocalFalconLocations(apiKey: string, query?: strin
  * @param {string} reportKey - The report key
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconLocationReport(apiKey: string, reportKey: string) {
+export async function fetchLocalFalconLocationReport(apiKey: string, reportKey: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/location-reports/${reportKey}`);
   url.searchParams.set("api_key", apiKey);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -504,7 +510,7 @@ export async function fetchLocalFalconLocationReport(apiKey: string, reportKey: 
  * @param {string} reportKey - The report key
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconReport(apiKey: string, reportKey: string) {
+export async function fetchLocalFalconReport(apiKey: string, reportKey: string, fieldmask?: string) {
   // Clean up the report key if it's a URL
   const cleanReportKey = reportKey.includes('/')
     ? reportKey.split('/').pop()
@@ -512,6 +518,7 @@ export async function fetchLocalFalconReport(apiKey: string, reportKey: string) 
 
   const url = new URL(`${API_BASE}/reports/${cleanReportKey}`);
   url.searchParams.set("api_key", apiKey);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -547,7 +554,7 @@ export async function fetchLocalFalconReport(apiKey: string, reportKey: string) 
  * @param {string} reportKey - The report key
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconTrendReport(apiKey: string, reportKey: string) {
+export async function fetchLocalFalconTrendReport(apiKey: string, reportKey: string, fieldmask?: string) {
   // Clean up the report key if it's a URL
   const cleanReportKey = reportKey.includes('/')
     ? reportKey.split('/').pop()
@@ -555,6 +562,7 @@ export async function fetchLocalFalconTrendReport(apiKey: string, reportKey: str
 
   const url = new URL(`${API_BASE}/trend-reports/${cleanReportKey}`);
   url.searchParams.set("api_key", apiKey);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -636,7 +644,7 @@ export async function fetchLocalFalconTrendReport(apiKey: string, reportKey: str
  * @param {string} keyword - Optional keyword filter
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconKeywordReports(apiKey: string, limit: string, nextToken?: string, keyword?: string, startDate?: string, endDate?: string) {
+export async function fetchLocalFalconKeywordReports(apiKey: string, limit: string, nextToken?: string, keyword?: string, startDate?: string, endDate?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/keyword-reports`);
   url.searchParams.set("api_key", apiKey);
   url.searchParams.set("limit", limit);
@@ -645,6 +653,7 @@ export async function fetchLocalFalconKeywordReports(apiKey: string, limit: stri
   if (startDate) url.searchParams.set("start_date", startDate);
   if (endDate) url.searchParams.set("end_date", endDate);
   if (keyword) url.searchParams.set("keyword", keyword);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -685,7 +694,7 @@ export async function fetchLocalFalconKeywordReports(apiKey: string, limit: stri
  * @param {string} reportKey - The report key
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconKeywordReport(apiKey: string, reportKey: string) {
+export async function fetchLocalFalconKeywordReport(apiKey: string, reportKey: string, fieldmask?: string) {
   // Clean up the report key if it's a URL
   const cleanReportKey = reportKey.includes('/')
     ? reportKey.split('/').pop()
@@ -693,6 +702,7 @@ export async function fetchLocalFalconKeywordReport(apiKey: string, reportKey: s
 
   const url = new URL(`${API_BASE}/keyword-reports/${cleanReportKey}`);
   url.searchParams.set("api_key", apiKey);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -756,13 +766,14 @@ export async function fetchLocalFalconGrid(apiKey: string, lat?: string, lng?: s
  * @param {string} near - Optional location filter
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconGoogleBusinessLocations(apiKey: string, nextToken?: string, query?: string, near?: string) {
+export async function fetchLocalFalconGoogleBusinessLocations(apiKey: string, nextToken?: string, query?: string, near?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/places`);
   url.searchParams.set("api_key", apiKey);
 
   if (nextToken) url.searchParams.set("next_token", nextToken);
   if (query) url.searchParams.set("query", query);
   if (near) url.searchParams.set("near", near);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -941,7 +952,7 @@ export async function fetchLocalFalconFullGridSearch(
  * @param {string} nextToken - Optional pagination token
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconCompetitorReports(apiKey: string, limit: string, startDate?: string, endDate?: string, placeId?: string, keyword?: string, gridSize?: string, nextToken?: string) {
+export async function fetchLocalFalconCompetitorReports(apiKey: string, limit: string, startDate?: string, endDate?: string, placeId?: string, keyword?: string, gridSize?: string, nextToken?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/competitor-reports`);
   url.searchParams.set("api_key", apiKey);
   url.searchParams.set("limit", limit);
@@ -952,6 +963,7 @@ export async function fetchLocalFalconCompetitorReports(apiKey: string, limit: s
   if (keyword) url.searchParams.set("keyword", keyword);
   if (gridSize) url.searchParams.set("grid_size", gridSize);
   if (nextToken) url.searchParams.set("next_token", nextToken);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -1000,7 +1012,7 @@ export async function fetchLocalFalconCompetitorReports(apiKey: string, limit: s
  * @param {boolean} lowDataMode - Whether to return less data
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconCompetitorReport(apiKey: string, reportKey: string, lowDataMode = true) {
+export async function fetchLocalFalconCompetitorReport(apiKey: string, reportKey: string, lowDataMode = true, fieldmask?: string) {
   // Clean up the report key if it's a URL
   const cleanReportKey = reportKey.includes('/')
     ? reportKey.split('/').pop()
@@ -1008,6 +1020,7 @@ export async function fetchLocalFalconCompetitorReport(apiKey: string, reportKey
 
   const url = new URL(`${API_BASE}/competitor-reports/${cleanReportKey}`);
   url.searchParams.set("api_key", apiKey);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -1063,7 +1076,7 @@ export async function fetchLocalFalconCompetitorReport(apiKey: string, reportKey
  * @param {string} nextToken - Optional pagination token
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconCampaignReports(apiKey: string, limit: string, startDate?: string, endDate?: string, placeId?: string, runDate?: string, nextToken?: string) {
+export async function fetchLocalFalconCampaignReports(apiKey: string, limit: string, startDate?: string, endDate?: string, placeId?: string, runDate?: string, nextToken?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/campaigns`);
   url.searchParams.set("api_key", apiKey);
   url.searchParams.set("limit", limit);
@@ -1073,6 +1086,7 @@ export async function fetchLocalFalconCampaignReports(apiKey: string, limit: str
   if (placeId) url.searchParams.set("place_id", placeId);
   if (runDate) url.searchParams.set("run", runDate);
   if (nextToken) url.searchParams.set("next_token", nextToken);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -1116,7 +1130,7 @@ export async function fetchLocalFalconCampaignReports(apiKey: string, limit: str
  * @param {string} reportKey - Report key
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconCampaignReport(apiKey: string, reportKey: string, runDate:string) {
+export async function fetchLocalFalconCampaignReport(apiKey: string, reportKey: string, runDate:string, fieldmask?: string) {
   // Clean up the report key if it's a URL
   const cleanReportKey = reportKey.includes('/')
     ? reportKey.split('/').pop()
@@ -1126,6 +1140,7 @@ export async function fetchLocalFalconCampaignReport(apiKey: string, reportKey: 
   url.searchParams.set("api_key", apiKey);
 
   if (runDate) url.searchParams.set("run", runDate);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -1152,7 +1167,7 @@ export async function fetchLocalFalconCampaignReport(apiKey: string, reportKey: 
  * @param {string} endDate - Optional end date filter
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconGuardReports(apiKey: string, limit: string, startDate?: string, endDate?: string, status?: string, nextToken?: string) {
+export async function fetchLocalFalconGuardReports(apiKey: string, limit: string, startDate?: string, endDate?: string, status?: string, nextToken?: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/guard`);
   url.searchParams.set("api_key", apiKey);
   url.searchParams.set("limit", limit);
@@ -1161,6 +1176,7 @@ export async function fetchLocalFalconGuardReports(apiKey: string, limit: string
   if (endDate) url.searchParams.set("end_date", endDate);
   if (status) url.searchParams.set("status", status);
   if (nextToken) url.searchParams.set("next_token", nextToken);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
   await rateLimiter.waitForAvailableSlot();
 
   return withRetry(async () => {
@@ -1196,9 +1212,10 @@ export async function fetchLocalFalconGuardReports(apiKey: string, limit: string
  * @param {string} placeId - Place ID
  * @returns {Promise<any>} API response
  */
-export async function fetchLocalFalconGuardReport(apiKey: string, placeId: string) {
+export async function fetchLocalFalconGuardReport(apiKey: string, placeId: string, fieldmask?: string) {
   const url = new URL(`${API_BASE}/guard/${placeId}`);
   url.searchParams.set("api_key", apiKey);
+  if (fieldmask) url.searchParams.set("fieldmask", fieldmask);
 
   await rateLimiter.waitForAvailableSlot();
 
@@ -1398,13 +1415,15 @@ export async function saveLocalFalconBusinessLocationToAccount(
  */
 export async function fetchLocalFalconAccountInfo(
   apiKey: string,
-  returnField?: 'user' | 'credit package' | 'subscription' | 'credits'
+  returnField?: 'user' | 'credit package' | 'subscription' | 'credits',
+  fieldmask?: string
 ): Promise<any> {
   try {
     await rateLimiter.waitForAvailableSlot();
     const form = new FormData();
     form.append('api_key', apiKey);
     if (returnField) form.append('return', returnField);
+    if (fieldmask) form.append('fieldmask', fieldmask);
     const response = await withRetry(async () => {
       return await fetchWithTimeout(
         `${API_BASE_V2}/account`,
@@ -1842,7 +1861,8 @@ export async function fetchLocalFalconReviewsAnalysisReports(
   placeId?: string,
   frequency?: string,
   limit?: number,
-  nextToken?: string
+  nextToken?: string,
+  fieldmask?: string
 ): Promise<any> {
   try {
     await rateLimiter.waitForAvailableSlot();
@@ -1853,6 +1873,7 @@ export async function fetchLocalFalconReviewsAnalysisReports(
     if (frequency) form.append('frequency', frequency);
     if (limit !== undefined) form.append('limit', limit.toString());
     if (nextToken) form.append('next_token', nextToken);
+    if (fieldmask) form.append('fieldmask', fieldmask);
 
     const response = await withRetry(async () => {
       return await fetchWithTimeout(
@@ -1886,13 +1907,15 @@ export async function fetchLocalFalconReviewsAnalysisReports(
  */
 export async function fetchLocalFalconReviewsAnalysisReport(
   apiKey: string,
-  reportKey: string
+  reportKey: string,
+  fieldmask?: string
 ): Promise<any> {
   try {
     await rateLimiter.waitForAvailableSlot();
     const form = new FormData();
     form.append('api_key', apiKey);
     form.append('report_key', reportKey);
+    if (fieldmask) form.append('fieldmask', fieldmask);
 
     const response = await withRetry(async () => {
       return await fetchWithTimeout(

--- a/server.ts
+++ b/server.ts
@@ -236,7 +236,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   });
 
   // Get list of Scan Reports
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "listLocalFalconScanReports",
     "Lists existing scan reports. ALWAYS check here before running new scans to avoid duplicates and save credits. Returns report metadata including date, keyword, location, ARP, ATRP, SoLV, grid size, and platform. Use filters to narrow results. If a report has a campaign_key, its data is consolidated in the campaign report — no separate trend/location/keyword reports exist for campaign scans. Use fieldmask to control returned fields. Recommended fieldmask for browsing: \"report_key,date,keyword,location.name,arp,atrp,solv,grid_size,platform\". Returns limited results per page; use nextToken for pagination.",
@@ -319,7 +318,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   );
 
   // Run a Dashboard Scan v2
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "runLocalFalconScan",
     "Runs a new ranking scan for a business. COSTS CREDITS — always confirm with the user before running. Requires: Place ID (business must be saved first), keyword, center coordinates (lat/lng), grid size, radius, measurement unit, and platform. Returns ranking data across the grid. Available platforms: google (Maps), apple (Apple Maps), gaio (Google AI Overviews), chatgpt (ChatGPT), gemini (Gemini), grok (Grok), aimode (Google AI Mode), giao (Google Immersive AI Overviews). Enable aiAnalysis for AI-generated insights on the results (Google Maps only). Grid size and radius should match the business type and service area.",
@@ -387,7 +385,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   );
 
   // Create a new Campaign
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "createLocalFalconCampaign",
     "Creates a new campaign in Local Falcon. Campaigns allow you to schedule recurring scans for one or multiple locations with one or multiple keywords. Locations must already exist in your Saved Locations (use listAllLocalFalconLocations to verify).",
@@ -509,7 +506,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   );
 
   // List all Reviews Analysis Reports
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "listLocalFalconReviewsAnalysisReports",
     `Lists Reviews Analysis reports in the account. These are premium AI-powered review analyses ($19/location) that evaluate up to 1M Google reviews for a target business plus up to 3 competitors. Separate from ranking scan reports. Filter by placeId, frequency, or reviewsKey. Use fieldmask to control returned fields. Recommended fieldmask: "reviews_key,name,date,locations,frequency,statistics.metrics.primaryBusiness". Use getLocalFalconReviewsAnalysisReport with a report key to see full results.`,
@@ -558,7 +554,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   );
 
   // Get list of Falcon Guard Reports
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "listLocalFalconGuardReports",
     `Lists locations monitored by Falcon Guard. Guard monitors Google Business Profiles for unwanted changes, checking twice daily. $1/month for up to 10 locations. OAuth-connected locations include enhanced metrics: calls, website clicks, directions, impressions (up to 18 months historical). Non-OAuth locations only show GBP change history. Use fieldmask to control returned fields. Recommended fieldmask: "report_key,place_id,location.name,location.address,location.rating,location.reviews,status,date_added,date_last". Filter by date range or status (protected/paused).`,
@@ -871,7 +866,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   );
 
   // On-Demand Endpoints for Single-Point Checks
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "getLocalFalconGrid",
     "Helper tool that generates grid coordinates for use with getLocalFalconRankingAtCoordinate or getLocalFalconKeywordAtCoordinate. Creates an array of lat/lng points based on your specified grid size and radius. NOTE: This is only useful if you're doing manual single-point checks. For comprehensive ranking analysis, skip this and use runLocalFalconScan instead, which handles grid creation automatically and provides full reports.",
@@ -914,7 +908,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
 
 
   // On-Demand Endpoint - Single Point Keyword Search
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "getLocalFalconKeywordAtCoordinate",
     "LIMITED TOOL - Shows raw search results at ONE SINGLE point without ranking analysis. Does not provide ranking positions or competitive insights. Only use for debugging or checking raw SERP data. For actual ranking analysis, use runLocalFalconScan.",
@@ -935,7 +928,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   );
 
   // Search for Business Location on Google or Apple
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "searchForLocalFalconBusinessLocation",
     "Searches for business locations on the specified platform. Returns a list of locations that match the search term.",
@@ -1003,7 +995,6 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   );
 
   // View Local Falcon Account Information
-  // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "viewLocalFalconAccountInformation",
     "Retrieves Local Falcon account information. Returns user, credit package, subscription, and credits.",

--- a/server.ts
+++ b/server.ts
@@ -8,7 +8,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 dotenv.config({ path: ".env.local" });
 
 
-const DEFAULT_LIMIT = "7"
+const DEFAULT_LIMIT = "10"
 
 function handleNullOrUndefined(value: string | null | undefined): string {
   if (value === null || value === undefined) {
@@ -39,7 +39,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
       },
     ],
     description: `You are a Local Falcon MCP Server. You are able to interact with the Local Falcon API to retrieve information about your Local Falcon reports and locations.
-      Note that sometimes you will run into an issue where responses are too verbose. If this happens use the lowDateMode option by default. If the user seems to be unsatisfied with the quanity of data returned, set lowDataMode to false.
+      Note that sometimes you will run into an issue where responses are too verbose. If this happens use the lowDataMode option by default. If the user seems to be unsatisfied with the quanity of data returned, set lowDataMode to false.
       Don't run a ton of tools sequentially with no direction, for example if the user asks for a scan reports don't run the tool for every other kind of report as well unless you're trying to do something important. Instead in that case you'd just summarize the scan reports for them.
       
       **Parameter Handling Note:**
@@ -144,7 +144,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
       gridSize: z.enum(['3', '5', '7', '9', '11', '13', '15']).describe("The size of the grid."),
       radius: z.string().describe("The radius of the grid from center point to outer most north/east/south/west point (0.1 to 100)."),
       measurement: z.enum(['mi', 'km']).describe("The measurement unit of the radius (mi for miles, km for kilometers)."),
-      platform: z.enum(['google', 'apple', 'gaio', 'chatgpt']).describe("The platform to run the scan against."),
+      platform: z.enum(['google', 'apple', 'gaio', 'chatgpt', 'gemini', 'grok']).describe("The platform to run the scan against."),
       aiAnalysis: z.boolean().default(false).describe("Whether AI analysis should be generated for this scan (optional, defaults to false)."),
     },
     async ({ placeId, keyword, lat, lng, gridSize, radius, measurement, platform, aiAnalysis }, ctx) => {
@@ -628,7 +628,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
       endDate: z.string().date().nullish().describe("Upper limit (newest) date you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       placeId: z.string().nullish().describe("Filter only results for specific Google Place ID. Supports multiple Google Place IDs, seperated by commas."),
       keyword: z.string().nullish().describe("Filter only results similar to specified keyword (loose match)."),
-      gridSize: z.enum(['3', '5', '7', '9', '11', '13', '15']).default("3").describe("Filter only for specific grid sizes. Expects 3, 5, 7, 9, 11, 13, or 15."),
+      gridSize: z.enum(['3', '5', '7', '9', '11', '13', '15']).nullish().describe("Filter only for specific grid sizes. Expects 3, 5, 7, 9, 11, 13, or 15."),
       nextToken: z.string().nullish().describe("This parameter is used to get the next 'page' of results. The value used with the parameter is provided from a previous response by this endpoint if more 'pages' of results exist."),
     },
     async ({ startDate, endDate, placeId, keyword, gridSize, nextToken }, ctx) => {
@@ -670,7 +670,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
       lng: z.string().describe("The longitude of the center of the grid."),
       gridSize: z.string().describe("Expects 3, 5, 7, 9, 11, 13, or 15."),
       radius: z.string().describe("The radius of the grid in meters. From 0.1 to 100."),
-      measurement: z.enum(['mi', 'km', 'null', 'undefined']).describe("Expects 'mi' or 'km'."),
+      measurement: z.enum(['mi', 'km']).nullish().describe("Expects 'mi' or 'km'."),
     },
     async ({ lat, lng, gridSize, radius, measurement }, ctx) => {
       const apiKey = getApiKey(ctx);
@@ -758,7 +758,6 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
     async ({ platform, placeId, name, lat, lng }, ctx) => {
       const apiKey = getApiKey(ctx);
 
-      console.info(`Found apikey: ${apiKey}`)
       if (!apiKey) {
         return {
           content: [
@@ -799,7 +798,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
     "viewLocalFalconAccountInformation",
     "Retrieves Local Falcon account information. Returns user, credit package, subscription, and credits.",
     {
-      returnField: z.enum(['user', 'credit package', 'subscription', 'credits', 'null', 'undefined']).nullish().describe("Optional specific return information"),
+      returnField: z.enum(['user', 'credit package', 'subscription', 'credits']).nullish().describe("Optional specific return information"),
     },
     async ({ returnField }, ctx) => {
       const apiKey = getApiKey(ctx);

--- a/server.ts
+++ b/server.ts
@@ -38,19 +38,200 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
         sizes: ["any"],
       },
     ],
-    description: `You are a Local Falcon MCP Server. You are able to interact with the Local Falcon API to retrieve information about your Local Falcon reports and locations.
-      Note that sometimes you will run into an issue where responses are too verbose. If this happens use the lowDataMode option by default. If the user seems to be unsatisfied with the quanity of data returned, set lowDataMode to false.
-      Don't run a ton of tools sequentially with no direction, for example if the user asks for a scan reports don't run the tool for every other kind of report as well unless you're trying to do something important. Instead in that case you'd just summarize the scan reports for them.
-      
-      **Parameter Handling Note:**
-    When calling Local Falcon API functions, omit optional parameters entirely when you don't have a useful value to provide. Do not pass null values or empty strings for parameters you're not actively using.
-  
-    Examples:
-    - Correct: \`listLocalFalconLocationReports({})\` (no filters needed)
-    - Correct: \`listLocalFalconLocationReports({"keyword": "web design"})\` (filtering by keyword)
-    - Incorrect: \`listLocalFalconLocationReports({"keyword": null, "placeId": ""})\` (passing unused parameters)
-  
-    Only include parameters when you have meaningful values that will filter or modify the API response.
+    description: `Local Falcon is a geo-grid rank tracking and local SEO analytics platform. This MCP server provides tools to run scans, retrieve reports, manage campaigns, monitor Google Business Profiles, and analyze competitive positioning across Google Maps, Apple Maps, and AI search platforms (ChatGPT, Gemini, Grok, Google AI Overviews, AI Mode).
+
+## CORE CONCEPTS
+
+**Scan:** A grid-based ranking analysis for one business + one keyword + one platform from a set of geographic coordinates. Each grid point checks who ranks at that location. Scans cost credits.
+
+**Google Business Profile (GBP):** Always use this term. Never say "Google My Business" or "GMB" — rebranded in 2021.
+
+**Service Area Business (SAB):** Businesses that serve customers at the customer's location (plumbers, HVAC, etc.). Their ranking patterns differ from storefronts — strong rankings far from the business address with weak rankings nearby is normal and expected for SABs. The center point of a scan should be where their customers are, not where their office is.
+
+**Place ID:** Google's unique identifier for a business location (format: ChIJXXXXXXXXXXXXXXXX). Required for running scans. Find via listAllLocalFalconLocations first, then searchForLocalFalconBusinessLocation or getLocalFalconGoogleBusinessLocations as fallbacks.
+
+## PLATFORMS & METRICS
+
+**Map Platforms (Google Maps, Apple Maps):**
+- ARP (Average Rank Position): Average rank only where the business appears. Measures ranking quality when visible.
+- ATRP (Average Total Rank Position): Average rank across ALL grid points including where the business doesn't appear (counted as 21). Primary metric for overall visibility.
+- SoLV (Share of Local Voice): Percentage of grid points where the business ranks in top 3 (the map pack). This is the most important map-based metric.
+- Competition SoLV: Count of unique competitors with any top-3 placements.
+- Max SoLV: Highest SoLV achieved by any single business in the scan.
+- Opportunity SoLV: Max SoLV minus your SoLV — quantifies realistic growth potential.
+- SoLV Distance / Average SoLV Distance: How far from the business location top-3 rankings extend. Measures geographic reach.
+- Found In: Number of grid points where the business appears at all.
+- Total Competitors: Count of all unique businesses appearing anywhere in results.
+- Distance from Center Point / Distance from Data Point: Geographic distance metrics for proximity analysis.
+
+**AI/Generative Platforms (ChatGPT, Gemini, Grok, AI Overviews, AI Mode):**
+- SAIV (Share of AI Visibility): Percentage of AI results mentioning the business. AI-only metric.
+- ARP/ATRP on AI scans are pseudo-ranks derived from mention order, not map positions.
+- NEVER confuse SAIV with SoLV — they measure completely different things on different platforms.
+
+**Review Metrics (from Reviews Analysis Reports):**
+- Review Volume Score (RVS): Composite of review velocity + total volume.
+- Review Quality Score (RQS): Composite of rating distribution, response engagement, and recency.
+- Review Velocity: Average reviews per month over last 90 days.
+- Review Freshness: Recency-weighted score of how current the review profile is.
+
+**Critical metric distinction:** SoLV is for maps ONLY. SAIV is for AI platforms ONLY. If a user mentions a SoLV drop and asks about AI visibility, correct the terminology before analyzing.
+
+## REPORT TYPES & RELATIONSHIPS
+
+**Scan Report** — Point-in-time ranking snapshot. User-initiated, costs credits. Foundation for all other report types. Contains full grid point data, aggregate metrics (ARP, ATRP, SoLV), competitor data, and optional AI analysis.
+
+**Trend Report** — Historical ranking changes over time. AUTO-GENERATED when 2+ scans exist with identical settings (same place ID, keyword, coordinates, grid, radius, platform). Shows ARP/ATRP/SoLV movement across scan dates. Cannot be created manually.
+
+**Competitor Report** — Competitive landscape from a scan. AUTO-GENERATED with every scan. Shows top-ranking businesses with their metrics, review counts, ratings, and positioning. Available for all platforms including AI scans.
+
+**Campaign Report** — Aggregated view across multiple locations and/or keywords on a schedule. User-configured. Consolidates all data in one report — scans run from campaigns do NOT generate separate location, keyword, or trend reports.
+
+**Location Report** — Aggregates all scans for a specific business location across keywords. AUTO-GENERATED after 2+ keywords scanned for the same location outside of campaigns.
+
+**Keyword Report** — Aggregates all scans for a specific keyword across locations. AUTO-GENERATED after 2+ locations scanned for the same keyword outside of campaigns.
+
+**Reviews Analysis Report** — AI-powered review analysis covering up to 1M reviews with competitor comparison. Separate from ranking reports. Premium feature ($19/location), does not use scan credits. Includes RVS, RQS, velocity, freshness, sentiment, and topic analysis.
+
+**Falcon Guard Report** — GBP monitoring service. Checks for profile changes twice daily and sends alerts. $1/month for up to 10 locations. OAuth-connected locations get enhanced data: calls, website clicks, directions, impressions (up to 18 months historical). Non-OAuth locations only get change history.
+
+## FIELDMASK USAGE
+
+Most get* and list* tools accept an optional \`fieldmask\` parameter — a comma-separated string of field names to return. **Always use fieldmasks** to request only the fields needed for the current task. This prevents context window overflow and improves performance.
+
+**Recommended fieldmasks by use case:**
+
+Scan report — quick overview:
+\`report_key,date,keyword,location.name,location.address,arp,atrp,solv,found_in,grid_size,radius,measurement\`
+
+Scan report — full analysis:
+\`report_key,date,place_id,keyword,location,lat,lng,grid_size,radius,measurement,arp,atrp,solv,found_in,total_competitors,competition_solv,max_solv,opportunity_solv,ai_analysis,image,heatmap\`
+
+Scan report list — browsing:
+\`report_key,date,keyword,location.name,arp,atrp,solv,grid_size,platform\`
+
+Trend report — performance tracking:
+\`report_key,last_date,keyword,location.name,scan_count,scans.*.date,scans.*.arp,scans.*.atrp,scans.*.solv\`
+
+Competitor report — competitive analysis:
+\`date,keyword,grid_size,radius,businesses.*.name,businesses.*.place_id,businesses.*.arp,businesses.*.atrp,businesses.*.solv,businesses.*.reviews,businesses.*.rating,businesses.*.lat,businesses.*.lng\`
+
+Campaign report list — overview:
+\`report_key,name,status,locations,keywords,frequency,last_run,next_run,arp,atrp,solv,arp_move,atrp_move,solv_move\`
+
+Campaign report — detailed:
+\`report_key,name,status,locations,keywords,frequency,last_run,next_run,arp,atrp,solv,arp_move,atrp_move,solv_move,scans,grid_size,radius,measurement\`
+
+Guard report list:
+\`report_key,place_id,location.name,location.address,location.rating,location.reviews,status,date_added,date_last\`
+
+Reviews analysis:
+\`reviews_key,name,date,locations,frequency,statistics.metrics.primaryBusiness\`
+
+**Fieldmask rules:**
+- Use dot notation for nested fields: \`location.name\`, \`statistics.metrics.primaryBusiness\`
+- Use wildcards for arrays: \`scans.*.arp\`, \`businesses.*.name\`
+- Start with the minimal fieldmask for the task, expand only if more data is needed
+- When a user asks a specific question (e.g., "what's my ARP?"), use a narrow fieldmask
+- When performing comprehensive analysis, use broader fieldmasks but still exclude raw grid point arrays when aggregate metrics suffice
+
+## TOOL WORKFLOW PATTERNS
+
+**Finding a business:**
+1. listAllLocalFalconLocations (check saved locations first)
+2. If not found: searchForLocalFalconBusinessLocation (search Google/Apple)
+3. Last resort: getLocalFalconGoogleBusinessLocations
+4. If needed: saveLocalFalconBusinessLocationToAccount (must be saved before scanning)
+
+**Analyzing current performance:**
+1. listLocalFalconScanReports (check for existing data — always do this before running new scans)
+2. getLocalFalconReport with appropriate fieldmask (get metrics + grid visualization)
+3. getLocalFalconCompetitorReport (see who's outranking the business and where)
+
+**Tracking changes over time:**
+1. listLocalFalconTrendReports (find existing trend reports)
+2. getLocalFalconTrendReport (view historical ARP/ATRP/SoLV movement)
+
+**Multi-location/keyword analysis:**
+1. listLocalFalconCampaignReports (find campaigns)
+2. getLocalFalconCampaignReport (get aggregated performance data)
+
+**Running new scans (costs credits — confirm with user):**
+1. Verify the location is saved (listAllLocalFalconLocations)
+2. Get coordinates (from saved location data or previous scan reports)
+3. runLocalFalconScan with appropriate grid size, radius, measurement, platform, keyword
+
+**Comprehensive location assessment:**
+For a full performance picture of a single location, gather (only if data exists):
+1. Latest scan report (getLocalFalconReport) — current ranking snapshot
+2. Competitor report (getLocalFalconCompetitorReport) — competitive landscape
+3. Trend report (getLocalFalconTrendReport) — historical trajectory
+4. Guard report (getLocalFalconGuardReport) — GBP health + engagement metrics
+5. Reviews analysis (getLocalFalconReviewsAnalysisReport) — review profile strength
+6. AI platform scan if available — AI visibility baseline
+Use fieldmasks on each call to keep context manageable. Not all report types will exist for every location.
+
+## INTERPRETING RESULTS
+
+**Scoring is always contextual.** There are no universal "good" or "bad" thresholds. Interpretation depends on:
+- Keyword competitiveness (e.g., "emergency plumber" is far more competitive than "antique clock repair")
+- Market density (urban downtown vs. rural area)
+- Scan radius (a 1-mile scan in Manhattan vs. a 15-mile scan in rural Texas)
+- Business category (restaurants have different competitive dynamics than law firms)
+- Business type (storefront vs. SAB)
+
+**Diagnostic patterns:**
+- Red/high-rank pins near the business + green/low-rank pins far away = competitor density problem near the business location. Common in urban areas. Consider Google Maps Ads for contested zones and focus organic efforts on opportunity areas.
+- Green pins far from business + red nearby (SAB) = normal SAB pattern. Verify center point is set to customer area, not office.
+- Good ARP (5-7) but low SoLV (<10%) = consistently ranking just outside the map pack (positions 4-10). On the bubble — small improvements could push into top 3.
+- High ARP (15+) = near-invisible. Check GBP verification status, primary category accuracy, and center point placement before optimizing.
+- SoLV above 80% with ARP below 3 = dominant position. Expand scan radius to find new markets or shift focus to conversion optimization.
+- Declining SoLV in trend reports with stable ARP = competitors improving, not necessarily the business declining. Check competitor report for new entrants.
+
+**Competitive analysis framework:**
+- Compare ARP, SoLV, review count, rating, and primary categories between the target business and top competitors.
+- High Opportunity SoLV with low Competition SoLV = untapped market potential, quick win zone.
+- High Competition SoLV with low Opportunity SoLV = saturated market, consider adjacent keywords or geographic expansion.
+- Competitors with significantly more reviews or higher ratings often dominate despite proximity disadvantages.
+
+**AI visibility analysis:**
+- Low SAIV = the business isn't being cited by AI platforms. Strategy should focus on becoming a citable source: get mentioned on authoritative sites, build structured data, increase real-world prominence signals.
+- AI rankings are emerging and volatile — recommend monitoring via regular scans but keeping primary strategic focus on maps (SoLV) where ranking factors are better understood.
+
+**Review analysis patterns:**
+- High RVS + low RQS = getting lots of reviews but not managing them well (low response rate, stale profile).
+- Low RVS + high RQS = well-managed but insufficient volume. Focus on review generation campaigns.
+- Low review freshness with high total reviews = historical authority but declining engagement signals.
+- Compare review velocity against top competitors — matching or exceeding their pace is the target.
+
+## SCAN CONFIGURATION GUIDANCE
+
+**Grid size:** Larger grids (11x11, 13x13, 15x15) provide more granular geographic coverage but cost more credits. Smaller grids (3x3, 5x5) are sufficient for quick checks or dense urban areas.
+
+**Radius:** Should reflect the realistic service area of the business.
+- Dense urban storefront: 1-3 miles
+- Suburban storefront: 3-5 miles
+- Service area business: 5-15+ miles depending on service radius
+- Rural business: 10-25+ miles
+
+**Platform selection:**
+- google: Standard Google Maps rankings (most common)
+- apple: Apple Maps rankings
+- gaio: Google AI Overviews
+- chatgpt: ChatGPT mentions/recommendations
+- gemini: Gemini AI mentions/recommendations
+- grok: Grok AI mentions/recommendations
+
+## OPERATIONAL RULES
+
+1. **Always check for existing data before running new scans.** Use listLocalFalconScanReports first. Scans cost credits.
+2. **Confirm with the user before running scans or any action that costs credits or money.**
+3. **Always use fieldmasks** on get* and list* tools. Start narrow, expand only if needed.
+4. **Omit optional parameters entirely** when you don't have a useful value. Do not pass null or empty strings.
+5. **Don't chain excessive tool calls.** If a user asks about scan reports, fetch scan reports — don't also fetch campaigns, trends, competitors, guard reports, and reviews unless specifically needed.
+6. **Use the Knowledge Base tools** (searchLocalFalconKnowledgeBase, getLocalFalconKnowledgeBaseArticle) for questions about Local Falcon features, settings, and how-to guidance. These return platform documentation, not user-specific data.
+7. **Pagination:** Most list tools return limited results per page. Use the nextToken from responses to fetch additional pages when needed.
+8. **Credit awareness:** runLocalFalconScan, runLocalFalconCampaign, and createLocalFalconCampaign consume credits. Use viewLocalFalconAccountInformation to check credit balance if relevant.
     `
   });
 
@@ -58,7 +239,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "listLocalFalconScanReports",
-    "ALWAYS USE THIS FIRST before running new scans. Shows all existing scan reports to check if the data you need already exists. Prevents duplicate scans and saves time. Check here before using runLocalFalconScan to see if a recent report is available. Lists reports with dates, keywords, and locations for easy identification. NOTE: If a scan shows a campaign_key, it means a campaign report exists with broader multi-location/keyword data. Campaign scans won't have separate location/keyword reports - all that data is consolidated in the campaign report instead.",
+    "Lists existing scan reports. ALWAYS check here before running new scans to avoid duplicates and save credits. Returns report metadata including date, keyword, location, ARP, ATRP, SoLV, grid size, and platform. Use filters to narrow results. If a report has a campaign_key, its data is consolidated in the campaign report — no separate trend/location/keyword reports exist for campaign scans. Use fieldmask to control returned fields. Recommended fieldmask for browsing: \"report_key,date,keyword,location.name,arp,atrp,solv,grid_size,platform\". Returns limited results per page; use nextToken for pagination.",
     { 
       nextToken: z.string().nullish().describe("Pagination token for additional results."),
       startDate: z.string().nullish().describe("A lower limit date of a scan report you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
@@ -84,7 +265,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get a Specific Scan Report
   server.tool(
     "getLocalFalconReport",
-    `EXISTING REPORT VIEWER ONLY - Retrieves previously created scan reports. CANNOT create new reports. WARNING: Only use this if you have a report_key from listLocalFalconScanReports. If you need NEW ranking data, use runLocalFalconScan instead. Common mistake: DO NOT use this hoping to generate a report - it only displays reports that already exist. The report URL format (https://www.localfalcon.com/reports/view/XXXXX) contains the report_key needed. NOTE: If this scan was part of a campaign, there will be a corresponding campaign report available (but NO separate location/keyword reports). Campaign reports provide a broader view across multiple locations/keywords which may be more valuable for comprehensive analysis.`,
+    `Retrieves a specific scan report by report_key. Returns full ranking data including ARP, ATRP, SoLV, grid point data, competitor summary, grid visualization images, and AI analysis text (if enabled). Use fieldmask to control response size — scan reports contain large grid point arrays that can overflow context. Recommended fieldmask for analysis: "report_key,date,place_id,keyword,location,arp,atrp,solv,found_in,total_competitors,competition_solv,max_solv,opportunity_solv,grid_size,radius,measurement,ai_analysis,image,heatmap". Add "places" to the fieldmask only when you need individual grid point data. Requires a report_key from listLocalFalconScanReports. Cannot create new reports — use runLocalFalconScan for that.`,
     {
       reportKey: z.string().describe("The report key of the scan report."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
@@ -141,7 +322,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "runLocalFalconScan",
-    "Runs a scan at the specified coordinate point and gets ranking data for a specified business.",
+    "Runs a new ranking scan for a business. COSTS CREDITS — always confirm with the user before running. Requires: Place ID (business must be saved first), keyword, center coordinates (lat/lng), grid size, radius, measurement unit, and platform. Returns ranking data across the grid. Available platforms: google (Maps), apple (Apple Maps), gaio (AI Overviews), chatgpt (ChatGPT), gemini (Gemini), grok (Grok). Enable aiAnalysis for AI-generated insights on the results (Google Maps only). Grid size and radius should match the business type and service area.",
     {
       placeId: z.string().describe("The Google Place ID of the business to match against in results."),
       keyword: z.string().describe("The desired search term or keyword."),
@@ -166,7 +347,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get list of Campaign Reports
   server.tool(
     "listLocalFalconCampaignReports",
-    "Lists all campaign reports in your account. Campaigns are the primary way to organize and track rankings at scale. Can include: single location + single keyword, multiple locations + single keyword, single location + multiple keywords, or multiple locations + multiple keywords. Most campaigns run on automated schedules (daily, weekly, monthly) making them the preferred method for ongoing tracking, but can also be run manually. Campaign reports consolidate all data in one place - no separate location/keyword reports are generated for campaign scans. Check here to see scheduled scan activity and multi-location/keyword performance data.",
+    `Lists campaign reports in the account. Campaigns are the primary method for scheduled, recurring scans across multiple locations and/or keywords. Can be configured as: single location + single keyword, multiple locations + single keyword, single location + multiple keywords, or multiple locations + multiple keywords. Campaign scans consolidate all data in the campaign report — no separate location/keyword/trend reports are generated. Use fieldmask to control returned fields. Recommended fieldmask: "report_key,name,status,locations,keywords,frequency,last_run,next_run,arp,atrp,solv,arp_move,atrp_move,solv_move".`,
     {
       startDate: z.string().date().nullish().describe("A lower limit date of a Campaign run you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       endDate: z.string().date().nullish().describe("Upper limit date of a Campaign run or schedule you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
@@ -189,7 +370,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get a Specific Campaign Report
   server.tool(
     "getLocalFalconCampaignReport",
-    "Campaign reports look like https://www.localfalcon.com/campaigns/view/0ee3c5869f3fa13 where 0ee3c5869f3fa13 is the report_key. Retrieves a specific campaign report that tracks multiple locations/keywords. Only for existing reports. Contains aggregated metrics (ARP, ATRP, SOLV), individual scan results, performance breakdowns by keyword and location, and scheduling info. Consolidates all data - no separate location/keyword reports exist for campaign scans.",
+    `Retrieves a specific campaign report with full details: aggregated ARP, ATRP, SoLV metrics, individual scan results, performance breakdowns by keyword and location, and scheduling info. Use the 'run' parameter (MM/DD/YYYY) to retrieve a specific historical run — defaults to the latest run. Use fieldmask to control response size — campaign reports with many locations/keywords can be very large. Recommended fieldmask for overview: "report_key,name,status,locations,keywords,arp,atrp,solv,arp_move,atrp_move,solv_move,frequency,last_run,next_run". Get the report_key from listLocalFalconCampaignReports.`,
     {
       reportKey: z.string().describe("The report_key of the Campaign Report you wish to retrieve."),
       run: z.string().nullish().describe("Optional specific campaign run date to retrieve (MM/DD/YYYY). Defaults to latest run."),
@@ -331,7 +512,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "listLocalFalconReviewsAnalysisReports",
-    "Retrieves the full list of all Reviews Analysis Reports within your Local Falcon account. Reviews Analysis Reports provide AI-powered analysis of your business reviews.",
+    `Lists Reviews Analysis reports in the account. These are premium AI-powered review analyses ($19/location) that evaluate up to 1M Google reviews for a target business plus up to 3 competitors. Separate from ranking scan reports. Filter by placeId, frequency, or reviewsKey. Use fieldmask to control returned fields. Recommended fieldmask: "reviews_key,name,date,locations,frequency,statistics.metrics.primaryBusiness". Use getLocalFalconReviewsAnalysisReport with a report key to see full results.`,
     {
       reviewsKey: z.string().nullish().describe("Filter by parent Reviews Analysis record key to retrieve only reports from that specific configuration."),
       placeId: z.string().nullish().describe("Filter by platform Place ID(s). Supports multiple IDs separated by commas."),
@@ -361,7 +542,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get specific Reviews Analysis Report
   server.tool(
     "getLocalFalconReviewsAnalysisReport",
-    "Retrieves the full result of a specific Reviews Analysis Report. Use listLocalFalconReviewsAnalysisReports to find the report_key for the report you want to retrieve.",
+    "Retrieves a specific Reviews Analysis report with full metrics: Review Volume Score (RVS), Review Quality Score (RQS), review velocity, freshness, total reviews, rating analysis, response rates, Local Guide reviews, photo reviews, and sentiment/topic analysis. Includes competitor comparison data if competitors were configured. Use fieldmask to control response size — review reports can be very large. Get the report key from listLocalFalconReviewsAnalysisReports.",
     {
       reportKey: z.string().describe("The key of the Reviews Analysis report you wish to retrieve."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
@@ -380,7 +561,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // @ts-expect-error TS2589 — SDK Zod type inference depth limit
   server.tool(
     "listLocalFalconGuardReports",
-    "Lists Falcon Guard reports IF they exist for your locations. Falcon Guard monitors Google Business Profile health and changes. NOTE: Not all locations have Guard reports. For OAuth-connected locations, reports include calls/clicks/directions data. For manually added locations, reports only show historical GBP changes.",
+    `Lists locations monitored by Falcon Guard. Guard monitors Google Business Profiles for unwanted changes, checking twice daily. $1/month for up to 10 locations. OAuth-connected locations include enhanced metrics: calls, website clicks, directions, impressions (up to 18 months historical). Non-OAuth locations only show GBP change history. Use fieldmask to control returned fields. Recommended fieldmask: "report_key,place_id,location.name,location.address,location.rating,location.reviews,status,date_added,date_last". Filter by date range or status (protected/paused).`,
     {
       startDate: z.string().date().nullish().describe("A lower limit date you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       endDate: z.string().date().nullish().describe("Upper limit date you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
@@ -500,7 +681,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get list of Trend Reports
   server.tool(
     "listLocalFalconTrendReports",
-    "Lists all existing trend reports that are AUTO-GENERATED when you run multiple scans with identical settings (same place ID, keyword, lat/lng, grid size, radius, platform). Trend reports show ranking changes over time and only appear after at least 2 identical scans. Check here to see historical ranking trends for a single location and single keyword at a time.",
+    `Lists trend reports showing ranking changes over time. These are AUTO-GENERATED when 2+ scans are run with IDENTICAL settings (same Place ID, keyword, coordinates, grid size, radius, platform). Each trend report tracks one location + one keyword combination. Requires at least 2 matching scans to exist. NOT generated for campaign scans — that historical data is in the campaign report. Use fieldmask to control returned fields. Recommended fieldmask: "report_key,last_date,keyword,location.name,location.address,scan_count,arp,arp_move,atrp,atrp_move,solv,solv_move". Filter by placeId, keyword, platform, or date range.`,
     {
       nextToken: z.string().nullish().describe("This parameter is used to get the next 'page' of results. The value used with the parameter is provided from a previous response by this endpoint if more 'pages' of results exist."),
       placeId: z.string().nullish().describe("Filter only results for specific Google Place ID. Supports multiple Google Place IDs, seperated by commas."),
@@ -524,7 +705,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get a Specific Trend Report
   server.tool(
     "getLocalFalconTrendReport",
-    "Retrieves an AUTO-GENERATED trend report showing ranking changes over time. A trend report looks like https://www.localfalcon.com/reports/trend/view/95290829819f6e8 where 95290829819f6e8 is the report key. These are automatically created when you run multiple scans with IDENTICAL settings (same place ID, keyword, coordinates, grid, radius, platform). Requires at least 2 identical scans to generate. Cannot be created manually.",
+    `Retrieves a specific trend report showing historical ARP, ATRP, and SoLV changes across multiple scan dates for one location + one keyword. Includes individual scan data points with dates, metrics, and grid images. Also includes competitor location data from the scans. Use fieldmask to control response size — trend reports with many scans can be large. Recommended fieldmask: "report_key,last_date,keyword,location.name,scan_count,scans.*.report_key,scans.*.date,scans.*.arp,scans.*.atrp,scans.*.solv". Add "scans.*.image,scans.*.heatmap" if grid visualizations are needed. Get the report_key from listLocalFalconTrendReports.`,
     {
       reportKey: z.string().describe("The report key of the trend report."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
@@ -567,7 +748,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get list of Location Reports
   server.tool(
     "listLocalFalconLocationReports",
-    "Lists all existing location reports that are AUTO-GENERATED after running runLocalFalconScan. NOTE: Location reports are NOT generated if the scan was initiated from a campaign (that data is included in the campaign report instead). These aggregate all scans for a specific business location. These will only be generated after a location has been scanned for at least 2 keywords outside of a campaign. ",
+    "Lists location reports that aggregate scan data across multiple keywords for a specific business location. AUTO-GENERATED after a location has been scanned for 2+ different keywords outside of campaigns. NOT generated for campaign scans. Useful for seeing how a location performs across its keyword portfolio. Use fieldmask to control returned fields.",
     {
       placeId: z.string().nullish().describe("The Place ID of the location."),
       keyword: z.string().nullish().describe("The keyword to search for."),
@@ -590,7 +771,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get a Specific Location Report
   server.tool(
     "getLocalFalconLocationReport",
-    "Retrieves a single location report. A location report looks like https://www.localfalcon.com/reports/location/view/c60c325a8665c4a where c60c325a8665c4a is the report key. Retrieves an AUTO-GENERATED location report that aggregates scan data for a specific business location. These are automatically created with runLocalFalconScan EXCEPT when scans are run from campaigns (campaign reports contain this data instead). Cannot be created manually. These will only be generated after a location has been scanned for at least 2 keywords outside of a campaign.",
+    "Retrieves a specific location report aggregating scan data across multiple keywords for one business location. Shows which keywords perform best/worst for that location. Use fieldmask to control response size. Get the report_key from listLocalFalconLocationReports.",
     {
       reportKey: z.string().describe("The report key of the location report."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
@@ -608,7 +789,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get list of Keyword Reports
   server.tool(
     "listLocalFalconKeywordReports",
-    "A keyword report looks like https://www.localfalcon.com/reports/keyword/view/754ffcb0f309938 where 754ffcb0f309938 is the report key. Lists all existing keyword reports that are AUTO-GENERATED after running runLocalFalconScan. NOTE: Keyword reports are NOT generated if the scan was initiated from a campaign (that data is included in the campaign report instead). These aggregate all scans for a specific keyword. These will only be generated after a keyword has been scanned for at least 2 locations outside of a campaign. ",
+    "Lists keyword reports that aggregate scan data across multiple locations for a specific keyword. AUTO-GENERATED after a keyword has been scanned for 2+ different locations outside of campaigns. NOT generated for campaign scans. Useful for comparing how different locations perform for the same keyword. Use fieldmask to control returned fields.",
     {
       nextToken: z.string().nullish().describe("Pagination token for additional results."),
       keyword: z.string().nullish().describe("The keyword to search for."),
@@ -630,7 +811,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get specific Keyword Report
   server.tool(
     "getLocalFalconKeywordReport",
-    "Retrieves an AUTO-GENERATED keyword report that aggregates scan data for a specific keyword. These are automatically created with runLocalFalconScan EXCEPT when scans are run from campaigns (campaign reports contain this data instead). Cannot be created manually. These will only be generated after a keyword has been scanned for at least 2 locations outside of a campaign. ",
+    "Retrieves a specific keyword report aggregating scan data across multiple locations for one keyword. Shows which locations perform best/worst for that keyword. Use fieldmask to control response size. Get the report_key from listLocalFalconKeywordReports.",
     {
       reportKey: z.string(),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
@@ -648,7 +829,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get list of Competitor Reports
   server.tool(
     "getLocalFalconCompetitorReports",
-    "Lists all existing competitor analysis reports that are AUTO-GENERATED after running runLocalFalconScan. Every scan automatically creates a competitor report showing top-ranking businesses in the area. You don't run these separately - they're created automatically with each scan.",
+    `Lists competitor analysis reports. One is AUTO-GENERATED with every scan, showing top-ranking businesses in the scanned area. Filter by placeId, keyword, date range, or grid size. Use fieldmask to control returned fields. Recommended fieldmask: "report_key,date,keyword,location.name,grid_size,platform".`,
     {
       startDate: z.string().date().nullish().describe("A lower limit (oldest) date you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       endDate: z.string().date().nullish().describe("Upper limit (newest) date you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
@@ -672,7 +853,7 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string }>) => {
   // Get specific Competitor Report
   server.tool(
     "getLocalFalconCompetitorReport",
-    "Competitor reports look like https://www.localfalcon.com/reports/competitor/view/08116fb5331e258 where 08116fb5331e258 is the report_key. Retrieves an AUTO-GENERATED competitor report that was created when you ran a scan. Shows top-ranking competitors from that scan. These reports are automatically created with every runLocalFalconScan - you cannot create them separately. Use the report_key from getLocalFalconCompetitorReports to view competitor data from a specific scan.",
+    `Retrieves a specific competitor report showing the competitive landscape from a scan. Includes top-ranking businesses with their ARP, ATRP, SoLV (or SAIV for AI scans), review counts, ratings, and geographic coordinates. lowDataMode=true (default) returns top 10 competitors; set to false for top 20. Use fieldmask to control which competitor fields are returned. Recommended fieldmask: "date,keyword,grid_size,radius,businesses.*.name,businesses.*.place_id,businesses.*.arp,businesses.*.atrp,businesses.*.solv,businesses.*.reviews,businesses.*.rating,businesses.*.lat,businesses.*.lng". Available for all platform types including AI scans. Get the report_key from getLocalFalconCompetitorReports.`,
     {
       reportKey: z.string().describe("The report_key of the Competitor Report you wish to retrieve."),
       lowDataMode: z.boolean().nullish().default(true).describe("Set to false to retrieve more data."),

--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import dotenv from "dotenv";
-import { fetchLocalFalconAutoScans, fetchLocalFalconFullGridSearch, fetchLocalFalconGoogleBusinessLocations, fetchLocalFalconGrid, fetchLocalFalconKeywordAtCoordinate, fetchLocalFalconKeywordReport, fetchLocalFalconKeywordReports, fetchLocalFalconLocationReport, fetchLocalFalconLocationReports, fetchAllLocalFalconLocations, fetchLocalFalconRankingAtCoordinate, fetchLocalFalconReport, fetchLocalFalconReports, fetchLocalFalconTrendReport, fetchLocalFalconTrendReports, fetchLocalFalconCompetitorReports, fetchLocalFalconCompetitorReport, fetchLocalFalconCampaignReports, fetchLocalFalconCampaignReport, fetchLocalFalconGuardReports, fetchLocalFalconGuardReport, runLocalFalconScan, searchForLocalFalconBusinessLocation, fetchLocalFalconAccountInfo, saveLocalFalconBusinessLocationToAccount, addLocationsToFalconGuard, pauseFalconGuardProtection, resumeFalconGuardProtection, removeFalconGuardProtection, createLocalFalconCampaign, runLocalFalconCampaign, pauseLocalFalconCampaign, resumeLocalFalconCampaign, reactivateLocalFalconCampaign, fetchLocalFalconReviewsAnalysisReports, fetchLocalFalconReviewsAnalysisReport } from "./localfalcon.js";
+import { fetchLocalFalconAutoScans, fetchLocalFalconFullGridSearch, fetchLocalFalconGoogleBusinessLocations, fetchLocalFalconGrid, fetchLocalFalconKeywordAtCoordinate, fetchLocalFalconKeywordReport, fetchLocalFalconKeywordReports, fetchLocalFalconLocationReport, fetchLocalFalconLocationReports, fetchAllLocalFalconLocations, fetchLocalFalconRankingAtCoordinate, fetchLocalFalconReport, fetchLocalFalconReports, fetchLocalFalconTrendReport, fetchLocalFalconTrendReports, fetchLocalFalconCompetitorReports, fetchLocalFalconCompetitorReport, fetchLocalFalconCampaignReports, fetchLocalFalconCampaignReport, fetchLocalFalconGuardReports, fetchLocalFalconGuardReport, runLocalFalconScan, searchForLocalFalconBusinessLocation, fetchLocalFalconAccountInfo, saveLocalFalconBusinessLocationToAccount, addLocationsToFalconGuard, pauseFalconGuardProtection, resumeFalconGuardProtection, removeFalconGuardProtection, createLocalFalconCampaign, runLocalFalconCampaign, pauseLocalFalconCampaign, resumeLocalFalconCampaign, reactivateLocalFalconCampaign, fetchLocalFalconReviewsAnalysisReports, fetchLocalFalconReviewsAnalysisReport, searchLocalFalconKnowledgeBase, getLocalFalconKnowledgeBaseArticle } from "./localfalcon.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
@@ -811,6 +811,45 @@ export const getServer = (sessionMapping: Map<string, { apiKey: string; isPro: b
       return { content: [{ type: "text", text: JSON.stringify(resp, null, 2) }] };
     },
   )
+
+  // Search Knowledge Base
+  server.tool(
+    "searchLocalFalconKnowledgeBase",
+    "Searches the Local Falcon Knowledge Base for help articles, how-to guides, and platform documentation. USE THIS TOOL when a user asks how to do something in Local Falcon, needs help understanding a feature, wants setup or configuration instructions, or is looking for best practices and tips. This is the go-to tool for any 'how do I...', 'what is...', 'how does... work', or 'help me with...' questions about the Local Falcon platform. Returns a list of matching articles with titles and summaries. Use getLocalFalconKnowledgeBaseArticle after this to retrieve the full step-by-step content of a specific article.",
+    {
+      q: z.string().nullish().describe("Search query to find relevant articles. Use natural language keywords like 'how to run a scan', 'campaign setup', 'grid size', 'credits', etc."),
+      categoryId: z.string().nullish().describe("Optional category ID to narrow results to a specific topic area."),
+      limit: z.string().nullish().describe("Maximum number of articles to return."),
+      nextToken: z.string().nullish().describe("Pagination token for additional results."),
+    },
+    async ({ q, categoryId, limit, nextToken }, ctx) => {
+      const apiKey = getApiKey(ctx);
+      if (!apiKey) {
+        return { content: [{ type: "text", text: "Missing LOCAL_FALCON_API_KEY in environment variables or request headers" }] };
+      }
+      const resp = await searchLocalFalconKnowledgeBase(apiKey, handleNullOrUndefined(q), handleNullOrUndefined(categoryId), handleNullOrUndefined(limit), handleNullOrUndefined(nextToken));
+      return { content: [{ type: "text", text: JSON.stringify(resp, null, 2) }] };
+    }
+  );
+
+  // Get Knowledge Base Article
+  server.tool(
+    "getLocalFalconKnowledgeBaseArticle",
+    "Retrieves the complete content of a specific Local Falcon Knowledge Base article, including full step-by-step instructions in markdown format. Use this AFTER searchLocalFalconKnowledgeBase to get the full guide for a specific article. If the user references an article by number (e.g. 'KB70', 'article 70', '#70'), strip any prefix and pass just the numeric ID. This is the tool that gives you the actual detailed instructions, walkthroughs, and explanations — the search tool only returns summaries.",
+    {
+      articleId: z.string().describe("The numeric ID of the Knowledge Base article to retrieve (e.g. '70'). If the user says 'KB70' or 'article 70', just pass '70'."),
+    },
+    async ({ articleId }, ctx) => {
+      const apiKey = getApiKey(ctx);
+      if (!apiKey) {
+        return { content: [{ type: "text", text: "Missing LOCAL_FALCON_API_KEY in environment variables or request headers" }] };
+      }
+      // Strip any non-numeric prefix (e.g. "KB70" -> "70")
+      const cleanId = articleId.replace(/^[^0-9]+/, '');
+      const resp = await getLocalFalconKnowledgeBaseArticle(apiKey, cleanId);
+      return { content: [{ type: "text", text: JSON.stringify(resp, null, 2) }] };
+    }
+  );
 
   return server;
 };


### PR DESCRIPTION
## Summary

- **Phase 1:** Fix 10 bugs — restore stripped fields (reportKey, lowDataMode), fix enum values (gridSize, platform, frequency), remove API key logging
- **Phase 2:** Add `fieldmask` parameter to all 20 get/list tools for response size control
- **Phase 3:** Update server description and 16 tool descriptions for clarity
- **Phase 4:** Fix 4 additional bugs found via OpenAPI spec cross-reference
- **Phase 5:** Strip `data_points` from scan report responses to prevent AI context overflow
- **Phase 6:** Add session auto-recovery for HTTP transport — when a `tools/call` arrives with a valid Bearer token but invalid/missing session ID, the server transparently creates a new session instead of returning 400. Includes rate limiting (5/min per API key) and full API key validation.
- **Docs:** Add CLAUDE.md with comprehensive developer documentation
- **Cleanup:** Remove 9 unused `@ts-expect-error` directives

## Files Changed

| File | Changes |
|---|---|
| `server.ts` | Bug fixes, fieldmask params, updated descriptions |
| `localfalcon.ts` | Restored fields, fixed param handling, data_points stripping |
| `index.ts` | Session auto-recovery with rate limiting and API key validation |
| `CLAUDE.md` | New — full project docs for AI-assisted development |
| `.gitignore` | Minor update |

## Test Plan

- [x] All 5 integration tests passed on `dh-dev-mcp.localfalcon.com` via claude.ai
- [x] Session auto-recovery confirmed working in production logs (Render)
- [x] `viewLocalFalconAccountInformation` — connection + credits ✅
- [x] `listLocalFalconScanReports` — ARP, ATRP, SoLV, image, heatmap, pdf, public_url ✅
- [x] `getLocalFalconReport` — full metrics + ai_analysis, no data_points ✅
- [x] `getLocalFalconCompetitorReports` — returns all grid sizes (not forced to 3) ✅
- [x] `listLocalFalconCampaignReports` — locations, keywords, frequency, status, metrics ✅
- [x] TypeScript strict mode — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)