### PR TITLE
v0.2.0: Add automated npm publishing and version bump

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,31 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@local-falcon/mcp",
-  "version": "0.1.30",
+  "version": "0.2.0",
   "description": "An MCP server for the Local Falcon API.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that auto-publishes to npm on GitHub Release creation
- Bump version from 0.1.30 to 0.2.0
- NPM_TOKEN secret has been configured on the repo

## Test plan
- [ ] Merge this PR
- [ ] Create a GitHub Release tagged v0.2.0
- [ ] Verify the Actions workflow runs and publishes to npm successfully