### PR TITLE
v1.4.0 — Connector improvements + production timeout fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ test.ts
 nul
 mcpb-packaging-brief.md
 *.mcpb
+
+# Diagnostic scratch work — not for commit
+scratch/
+briefs/

--- a/localfalcon.test.ts
+++ b/localfalcon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isTimeoutError } from "./localfalcon";
+import { buildEagerPendingResponse, buildScanTimeoutFallback, isTimeoutError } from "./localfalcon";
 
 describe("isTimeoutError", () => {
   test("matches fetchWithTimeout's actual error message ('timed out', two words)", () => {
@@ -34,5 +34,81 @@ describe("isTimeoutError", () => {
     expect(isTimeoutError(null)).toBe(false);
     expect(isTimeoutError(undefined)).toBe(false);
     expect(isTimeoutError({ message: "timeout" })).toBe(false);
+  });
+});
+
+describe("buildEagerPendingResponse (HTTP 202 branch)", () => {
+  const params = {
+    placeId: "ChIJxxx",
+    keyword: "coffee near me",
+    gridSize: "5",
+    platform: "google",
+  };
+
+  test("surfaces report_key and status from data.data", () => {
+    const apiResponse = {
+      code: 202,
+      success: true,
+      message: "Your scan has been created and is currently in progress.",
+      data: { report_key: "abc123def456789", status: "pending" },
+    };
+    const result = buildEagerPendingResponse(apiResponse, params);
+
+    expect(result.success).toBe(true);
+    expect(result.report_key).toBe("abc123def456789");
+    expect(result.status).toBe("pending");
+    expect(result.place_id).toBe(params.placeId);
+    expect(result.keyword).toBe(params.keyword);
+    expect(result.grid_size).toBe(params.gridSize);
+    expect(result.platform).toBe(params.platform);
+    expect(result.message).toContain("abc123def456789");
+    expect(result.message).toContain("Poll getLocalFalconReport");
+    expect(result._mcp_note).toContain("Do NOT retry");
+  });
+
+  test("defaults status to 'pending' when the server omits it", () => {
+    const apiResponse = { data: { report_key: "xyz" } };
+    const result = buildEagerPendingResponse(apiResponse, params);
+    expect(result.status).toBe("pending");
+    expect(result.report_key).toBe("xyz");
+  });
+
+  test("falls back to a listing-based recovery message when report_key is missing", () => {
+    // Defensive: the server currently always sets report_key on 202, but the
+    // helper handles the missing-key case without throwing.
+    const apiResponse = { data: {} };
+    const result = buildEagerPendingResponse(apiResponse, params);
+
+    expect(result.success).toBe(true);
+    expect(result.report_key).toBeUndefined();
+    expect(result.message).toContain("listLocalFalconScanReports");
+    expect(result.message).not.toContain("Report key:");
+  });
+});
+
+describe("buildScanTimeoutFallback (network-timeout branch)", () => {
+  const params = {
+    placeId: "ChIJyyy",
+    keyword: "test keyword",
+    gridSize: "3",
+    platform: "chatgpt",
+  };
+
+  test("returns synthetic success with recovery guidance", () => {
+    const result = buildScanTimeoutFallback(params);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("network timeout");
+    expect(result.message).toContain("listLocalFalconScanReports");
+    expect(result.place_id).toBe(params.placeId);
+    expect(result.keyword).toBe(params.keyword);
+    expect(result.grid_size).toBe(params.gridSize);
+    expect(result.platform).toBe(params.platform);
+    expect(result._mcp_note).toContain("Do NOT retry");
+  });
+
+  test("does not carry a report_key (unrecoverable from this code path)", () => {
+    const result = buildScanTimeoutFallback(params);
+    expect(result.report_key).toBeUndefined();
   });
 });

--- a/localfalcon.test.ts
+++ b/localfalcon.test.ts
@@ -196,7 +196,7 @@ describe("unwrapWithWarnings", () => {
     expect(result._warnings).toEqual(["Unknown field in fieldmask: x"]);
   });
 
-  test("real V.2 probe shape: data has 6 good fields + 4 exceptions", () => {
+  test("real API response shape: data has 6 good fields + 4 exceptions", () => {
     // Shape from scratch/session-2/verification/V2-raw-api-response.json
     const wrapper = {
       code: 200,
@@ -321,7 +321,7 @@ describe("fetch-function unwrap pattern (end-to-end simulation)", () => {
 });
 
 describe("parseApiError", () => {
-  test("404 with standard wrapper (verified V.3 shape): rewrites to 'Report not found' + server suffix", () => {
+  test("404 with standard wrapper shape: rewrites to 'Report not found' + server suffix", () => {
     const wrapper = JSON.stringify({
       code: 404,
       code_desc: false,
@@ -378,7 +378,7 @@ describe("parseApiError", () => {
   });
 
   test("plain-text error body (non-JSON, e.g., reviewsAnalysis endpoint): falls back to status + body", () => {
-    // The reviewsAnalysis endpoint in V.3 returned plain text, not the standard wrapper
+    // Some endpoints (e.g., reviewsAnalysis) return plain text rather than the standard wrapper
     const err = parseApiError(500, "You do not have permission to access this resource.");
     expect(err.message).toContain("status 500");
     expect(err.message).toContain("You do not have permission");

--- a/localfalcon.test.ts
+++ b/localfalcon.test.ts
@@ -197,7 +197,6 @@ describe("unwrapWithWarnings", () => {
   });
 
   test("real API response shape: data has 6 good fields + 4 exceptions", () => {
-    // Shape from scratch/session-2/verification/V2-raw-api-response.json
     const wrapper = {
       code: 200,
       code_desc: false,

--- a/localfalcon.test.ts
+++ b/localfalcon.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { isTimeoutError } from "./localfalcon";
+
+describe("isTimeoutError", () => {
+  test("matches fetchWithTimeout's actual error message ('timed out', two words)", () => {
+    // The message format thrown by fetchWithTimeout. Previously missed by .includes('timeout').
+    expect(isTimeoutError(new Error("Request timed out after 15000ms"))).toBe(true);
+  });
+
+  test("matches 'timeout' (one word) variants", () => {
+    expect(isTimeoutError(new Error("Connection timeout"))).toBe(true);
+    expect(isTimeoutError(new Error("Upstream timeout after 5s"))).toBe(true);
+  });
+
+  test("is case insensitive", () => {
+    expect(isTimeoutError(new Error("TIMEOUT"))).toBe(true);
+    expect(isTimeoutError(new Error("Request TIMED OUT"))).toBe(true);
+  });
+
+  test("matches AbortError by name even if message is empty", () => {
+    const e = new Error("");
+    e.name = "AbortError";
+    expect(isTimeoutError(e)).toBe(true);
+  });
+
+  test("returns false for non-timeout Errors", () => {
+    expect(isTimeoutError(new Error("Invalid input"))).toBe(false);
+    expect(isTimeoutError(new Error("HTTP 500 Internal Server Error"))).toBe(false);
+    expect(isTimeoutError(new Error(""))).toBe(false);
+  });
+
+  test("returns false for non-Error values", () => {
+    expect(isTimeoutError("timeout string, not Error")).toBe(false);
+    expect(isTimeoutError(null)).toBe(false);
+    expect(isTimeoutError(undefined)).toBe(false);
+    expect(isTimeoutError({ message: "timeout" })).toBe(false);
+  });
+});

--- a/localfalcon.test.ts
+++ b/localfalcon.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { buildEagerPendingResponse, buildScanTimeoutFallback, isTimeoutError } from "./localfalcon";
+import {
+  buildEagerPendingResponse,
+  buildScanTimeoutFallback,
+  isTimeoutError,
+  parseApiError,
+  unwrapWithWarnings,
+} from "./localfalcon";
 
 describe("isTimeoutError", () => {
   test("matches fetchWithTimeout's actual error message ('timed out', two words)", () => {
@@ -110,5 +116,303 @@ describe("buildScanTimeoutFallback (network-timeout branch)", () => {
   test("does not carry a report_key (unrecoverable from this code path)", () => {
     const result = buildScanTimeoutFallback(params);
     expect(result.report_key).toBeUndefined();
+  });
+});
+
+describe("unwrapWithWarnings", () => {
+  test("no warnings: returns inner data unchanged", () => {
+    const wrapper = {
+      code: 200,
+      success: true,
+      message: false,
+      parameters: [],
+      data: { report_key: "abc", keyword: "coffee" },
+    };
+    const result = unwrapWithWarnings(wrapper);
+    expect(result).toEqual({ report_key: "abc", keyword: "coffee" });
+    expect(result._warnings).toBeUndefined();
+  });
+
+  test("no .data key: falls back to the response itself (matches existing ?? pattern)", () => {
+    const shapeless = { some: "thing", no_data_key: true };
+    const result = unwrapWithWarnings(shapeless);
+    expect(result).toEqual(shapeless);
+  });
+
+  test("warnings present: object inner gains _warnings sibling", () => {
+    const wrapper = {
+      data: { report_key: "abc", arp: "3.80" },
+      field_mask_warnings: {
+        message: "Some field masks were not found in the data.",
+        exceptions: ["reports.fake.name", "foo.bar"],
+      },
+    };
+    const result = unwrapWithWarnings(wrapper);
+    expect(result.report_key).toBe("abc");
+    expect(result.arp).toBe("3.80");
+    expect(result._warnings).toEqual([
+      "Unknown field in fieldmask: reports.fake.name",
+      "Unknown field in fieldmask: foo.bar",
+    ]);
+  });
+
+  test("empty exceptions array is treated as no warnings", () => {
+    const wrapper = {
+      data: { a: 1 },
+      field_mask_warnings: { exceptions: [] },
+    };
+    const result = unwrapWithWarnings(wrapper);
+    expect(result).toEqual({ a: 1 });
+    expect(result._warnings).toBeUndefined();
+  });
+
+  test("warnings + array inner: wraps into { items, _warnings }", () => {
+    const wrapper = {
+      data: [{ id: 1 }, { id: 2 }],
+      field_mask_warnings: { exceptions: ["bad.path"] },
+    };
+    const result = unwrapWithWarnings(wrapper);
+    expect(result.items).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result._warnings).toEqual(["Unknown field in fieldmask: bad.path"]);
+  });
+
+  test("warnings + scalar inner: wraps into { value, _warnings }", () => {
+    const wrapper = {
+      data: "just-a-string",
+      field_mask_warnings: { exceptions: ["x"] },
+    };
+    const result = unwrapWithWarnings(wrapper);
+    expect(result.value).toBe("just-a-string");
+    expect(result._warnings).toEqual(["Unknown field in fieldmask: x"]);
+  });
+
+  test("warnings + null inner: wraps safely", () => {
+    const wrapper = {
+      data: null,
+      field_mask_warnings: { exceptions: ["x"] },
+    };
+    const result = unwrapWithWarnings(wrapper);
+    expect(result.value).toBe(null);
+    expect(result._warnings).toEqual(["Unknown field in fieldmask: x"]);
+  });
+
+  test("real V.2 probe shape: data has 6 good fields + 4 exceptions", () => {
+    // Shape from scratch/session-2/verification/V2-raw-api-response.json
+    const wrapper = {
+      code: 200,
+      code_desc: false,
+      success: true,
+      message: false,
+      parameters: [],
+      data: {
+        report_key: "ad412d968a25a84",
+        date: "4/14/2026 4:00 PM",
+        platform: "google",
+        arp: "3.80",
+        atrp: "11.44",
+        solv: "22.22",
+      },
+      field_masks: [
+        "report_key", "date", "platform", "arp", "atrp", "solv",
+        "reports.fake.name", "totally_bogus_field", "insights.notreal", "foo.bar.baz",
+      ],
+      field_mask_warnings: {
+        message: "Some field masks were not found in the data.",
+        exceptions: [
+          "reports.fake.name",
+          "totally_bogus_field",
+          "insights.notreal",
+          "foo.bar.baz",
+        ],
+      },
+    };
+
+    const result = unwrapWithWarnings(wrapper);
+    expect(result.report_key).toBe("ad412d968a25a84");
+    expect(result.arp).toBe("3.80");
+    expect(result.solv).toBe("22.22");
+    expect(result._warnings).toEqual([
+      "Unknown field in fieldmask: reports.fake.name",
+      "Unknown field in fieldmask: totally_bogus_field",
+      "Unknown field in fieldmask: insights.notreal",
+      "Unknown field in fieldmask: foo.bar.baz",
+    ]);
+  });
+});
+
+// Integration-style verification of unwrapWithWarnings through the actual response-
+// handling path used by fetch functions. We don't mock node-fetch here (it's imported
+// at the module level, complicating test isolation); instead we simulate the exact
+// sequence a fetch function performs: safeParseJson → unwrapWithWarnings → project →
+// strip data_points, and assert the final MCP shape. Functionally equivalent to
+// end-to-end testing of the wrapper-processing logic, minus the network round-trip.
+describe("fetch-function unwrap pattern (end-to-end simulation)", () => {
+  test("list-with-slicing + warnings: spread preserves _warnings through the slice", () => {
+    const apiResponse = {
+      code: 200,
+      success: true,
+      parameters: [],
+      data: {
+        reports: [{ report_key: "r1" }, { report_key: "r2" }, { report_key: "r3" }],
+        count: 3,
+        total: 9370,
+        next_token: "tok",
+      },
+      field_mask_warnings: { exceptions: ["garbage.field"] },
+    };
+    const unwrapped = unwrapWithWarnings(apiResponse);
+    const limitNum = 2;
+    const result = {
+      ...unwrapped,
+      reports: unwrapped.reports.slice(0, limitNum),
+    };
+
+    expect(result.reports.length).toBe(2);
+    expect(result.reports[0].report_key).toBe("r1");
+    expect(result.count).toBe(3);
+    expect(result.total).toBe(9370);
+    expect(result.next_token).toBe("tok");
+    expect(result._warnings).toEqual(["Unknown field in fieldmask: garbage.field"]);
+  });
+
+  test("single-get + warnings + data_points strip: _warnings survives destructure", () => {
+    const apiResponse = {
+      code: 200,
+      success: true,
+      data: {
+        report_key: "abc",
+        arp: "3.80",
+        data_points: [{ huge: true }],
+      },
+      field_mask_warnings: { exceptions: ["nope"] },
+    };
+    const unwrapped = unwrapWithWarnings(apiResponse);
+    // Strip data_points the way fetchLocalFalconReport does
+    const { data_points, ...cleanData } = unwrapped;
+
+    expect(cleanData.report_key).toBe("abc");
+    expect(cleanData.arp).toBe("3.80");
+    expect(cleanData.data_points).toBeUndefined();
+    expect(cleanData._warnings).toEqual(["Unknown field in fieldmask: nope"]);
+  });
+
+  test("projection branch (fetchLocalFalconTrendReports-style): conditional _warnings include", () => {
+    const apiResponse = {
+      data: {
+        next_token: "t",
+        ai_analysis: "x",
+        reports: [{ report_key: "r", last_date: "d", location: "l", keywords: [] }],
+      },
+      field_mask_warnings: { exceptions: ["fake"] },
+    };
+    const unwrapped = unwrapWithWarnings(apiResponse);
+
+    // Mirror the projection-branch pattern: build the object, add _warnings only if present
+    const out: any = {
+      next_token: unwrapped.next_token,
+      ai_analysis: unwrapped.ai_analysis,
+      reports: unwrapped.reports.slice(0, 10),
+    };
+    if (unwrapped._warnings) out._warnings = unwrapped._warnings;
+
+    expect(out.next_token).toBe("t");
+    expect(out._warnings).toEqual(["Unknown field in fieldmask: fake"]);
+  });
+});
+
+describe("parseApiError", () => {
+  test("404 with standard wrapper (verified V.3 shape): rewrites to 'Report not found' + server suffix", () => {
+    const wrapper = JSON.stringify({
+      code: 404,
+      code_desc: false,
+      success: false,
+      message: "The report you requested is not available or you do not have permission to view it.",
+      parameters: [],
+      data: [],
+    });
+    const err = parseApiError(404, wrapper);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("Report not found");
+    expect(err.message).toContain("may not exist, may have expired, or may belong to a different account");
+    expect(err.message).toContain("(Server:"); // server message preserved
+    expect(err.message).toContain("not available or you do not have permission");
+  });
+
+  test("403 with standard wrapper: rewrites to explicit 'Access denied'", () => {
+    const wrapper = JSON.stringify({
+      code: 403,
+      success: false,
+      message: "The report you requested is not available or you do not have permission to view it.",
+    });
+    const err = parseApiError(403, wrapper);
+    expect(err.message).toContain("Access denied");
+    expect(err.message).toContain("different account");
+    expect(err.message).toContain("(Server:");
+  });
+
+  test("400 with server message: passes server message through via suffix", () => {
+    const wrapper = JSON.stringify({
+      code: 400,
+      success: false,
+      message: "You must specify a report key.",
+    });
+    const err = parseApiError(400, wrapper);
+    expect(err.message).toContain("Invalid request (400)");
+    expect(err.message).toContain("You must specify a report key");
+  });
+
+  test("401 maps to 'Authentication failed'", () => {
+    const wrapper = JSON.stringify({
+      code: 401,
+      success: false,
+      message: "The API key you provided is not valid or no longer active.",
+    });
+    const err = parseApiError(401, wrapper);
+    expect(err.message).toContain("Authentication failed");
+    expect(err.message).toContain("API key");
+  });
+
+  test("429 maps to 'Rate limit exceeded'", () => {
+    const err = parseApiError(429, JSON.stringify({ code: 429, message: "Too many requests" }));
+    expect(err.message).toContain("Rate limit exceeded");
+  });
+
+  test("plain-text error body (non-JSON, e.g., reviewsAnalysis endpoint): falls back to status + body", () => {
+    // The reviewsAnalysis endpoint in V.3 returned plain text, not the standard wrapper
+    const err = parseApiError(500, "You do not have permission to access this resource.");
+    expect(err.message).toContain("status 500");
+    expect(err.message).toContain("You do not have permission");
+  });
+
+  test("accepts an already-parsed data object (action-endpoint call pattern)", () => {
+    const parsed = { code: 404, message: "The report you requested is not available..." };
+    const err = parseApiError(404, parsed);
+    expect(err.message).toContain("Report not found");
+    expect(err.message).toContain("(Server:");
+  });
+
+  test("empty server message: falls back gracefully", () => {
+    const err = parseApiError(404, JSON.stringify({ code: 404, message: "" }));
+    expect(err.message).toContain("Report not found");
+    expect(err.message).not.toContain("(Server:"); // no suffix when message is empty
+  });
+
+  test("unknown 5xx: generic fallback with status", () => {
+    const err = parseApiError(503, JSON.stringify({ code: 503, message: "Service unavailable" }));
+    expect(err.message).toContain("Local Falcon API error: 503");
+    expect(err.message).toContain("Service unavailable");
+  });
+
+  test("totally empty error body: doesn't crash, generic fallback", () => {
+    const err = parseApiError(500, "");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("500");
+  });
+
+  test("server code differs from status (takes server code)", () => {
+    // If the server returns HTTP 200 but code:404 in body (unusual but possible)
+    const wrapper = JSON.stringify({ code: 404, message: "nope" });
+    const err = parseApiError(200, wrapper);
+    expect(err.message).toContain("Report not found");
   });
 });

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -258,13 +258,13 @@ export function isTimeoutError(error: unknown): boolean {
 // error check). Maps the server's status code to specific agent-facing guidance;
 // preserves the server's message as supplemental context.
 //
-// Mapping is driven by V.3 probe evidence:
+// Mapping is driven by observed API behavior:
 //   - 404: server message conflates "not available / no permission"; MCP rewrites
 //     to "not found OR different account OR expired" so agents understand the
 //     options. Server message attached for transparency.
 //   - 403: similar conflation; MCP rewrites to be explicit about auth/account scope.
-//   - 400: server-side malformed input (M6's Zod validation catches client-side
-//     malformed input before the request). Pass the server message through.
+//   - 400: server-side malformed input (schema-level Zod validation catches
+//     client-side malformed input before the request). Pass the server message through.
 //   - 401: auth failure — "Check your API key."
 //   - 429: rate-limited — "Wait a moment before retrying."
 //   - Non-JSON error body (e.g., reviewsAnalysis plain text): pass through with a
@@ -1656,11 +1656,11 @@ export async function runLocalFalconScan(
     form.append('measurement', measurement);
     form.append('platform', platform);
     form.append('ai_analysis', aiAnalysis.toString());
-    // eager=1 tells LF.api's methods/v2/run-scan/method.php runtime_check() to cap
-    // its server-side wait at 20s instead of 360s. If the scan completes in <20s we
-    // get HTTP 200 with the full report; otherwise HTTP 202 with data.report_key
-    // populated so the agent can poll via getLocalFalconReport. Resolves Bug #2
-    // (submission previously returned no report_key on timeout).
+    // eager=1 tells the server-side run-scan handler to cap its completion-wait at
+    // 20s instead of 360s. If the scan finishes in <20s we get HTTP 200 with the
+    // full report; otherwise HTTP 202 with data.report_key populated so the agent
+    // can poll via getLocalFalconReport. Previously the MCP's 15s timeout consistently
+    // fired before the server responded, so the report_key was never surfaced.
     form.append('eager', '1');
 
     // Server's eager budget is 20s (runtime_check in LF.api). 25s keeps a 5s margin so

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -242,6 +242,16 @@ async function fetchWithTimeout(url: string, options = {}, timeoutMs = DEFAULT_T
   }
 }
 
+// Matches both "timeout" (one word) and "timed out" (two words). The fetchWithTimeout
+// helper above throws "Request timed out after Nms", so a naive .includes('timeout')
+// check misses it — the bug that caused scan submissions to surface as errors instead
+// of the intended "submitted and processing" success response.
+export function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'AbortError') return true;
+  return /timeout|timed out/i.test(error.message ?? '');
+}
+
 // Rate limiting implementation
 class RateLimiter {
   maxRequests: number;
@@ -1487,7 +1497,7 @@ export async function runLocalFalconScan(
       );
     } catch (error) {
       // Timeout = scan was submitted and is processing (this is expected, not an error)
-      if ((error as Error).name === 'AbortError' || (error as Error).message?.includes('timeout')) {
+      if (isTimeoutError(error)) {
         return {
           success: true,
           message: "Scan submitted successfully and is now processing. Scans typically take 30 seconds to several minutes to complete depending on grid size and queue load.",

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -252,6 +252,124 @@ export function isTimeoutError(error: unknown): boolean {
   return /timeout|timed out/i.test(error.message ?? '');
 }
 
+// Parses a Local Falcon API error into a clearer MCP Error. Accepts either the raw
+// response body as a string (from `await res.text()`) or the already-parsed data
+// object (as used by scan/action endpoints that call safeParseJson before the
+// error check). Maps the server's status code to specific agent-facing guidance;
+// preserves the server's message as supplemental context.
+//
+// Mapping is driven by V.3 probe evidence:
+//   - 404: server message conflates "not available / no permission"; MCP rewrites
+//     to "not found OR different account OR expired" so agents understand the
+//     options. Server message attached for transparency.
+//   - 403: similar conflation; MCP rewrites to be explicit about auth/account scope.
+//   - 400: server-side malformed input (M6's Zod validation catches client-side
+//     malformed input before the request). Pass the server message through.
+//   - 401: auth failure — "Check your API key."
+//   - 429: rate-limited — "Wait a moment before retrying."
+//   - Non-JSON error body (e.g., reviewsAnalysis plain text): pass through with a
+//     generic "Local Falcon API error" prefix and status.
+//   - Unknown/5xx: generic fallback with status + server message.
+export function parseApiError(status: number, errorBody: string | any): Error {
+  let parsed: any = null;
+  if (typeof errorBody === 'string') {
+    try {
+      parsed = JSON.parse(errorBody);
+    } catch {
+      // Non-JSON body (e.g., plain-text error from some endpoints)
+    }
+  } else if (errorBody && typeof errorBody === 'object') {
+    parsed = errorBody;
+  }
+
+  const rawMessage = typeof parsed?.message === 'string' ? parsed.message.trim() : '';
+  const serverMessage = rawMessage.length > 0 ? rawMessage : undefined;
+  const serverCode = typeof parsed?.code === 'number' ? parsed.code : status;
+  const serverSuffix = serverMessage ? ` (Server: ${serverMessage})` : '';
+
+  const effectiveStatus = serverCode || status;
+
+  if (effectiveStatus === 404) {
+    return new Error(
+      `Report not found. The reportKey may not exist, may have expired, or may belong to a different account. Verify the reportKey is correct.${serverSuffix}`
+    );
+  }
+  if (effectiveStatus === 403) {
+    return new Error(
+      `Access denied. This resource belongs to a different account, or the API key / OAuth token lacks permission. Verify the API key and scope.${serverSuffix}`
+    );
+  }
+  if (effectiveStatus === 400) {
+    const fallbackText =
+      typeof errorBody === 'string' && !parsed ? ` ${errorBody.trim().slice(0, 500)}` : '';
+    return new Error(
+      `Invalid request (400).${serverSuffix || fallbackText || ' No server detail provided.'}`
+    );
+  }
+  if (effectiveStatus === 401) {
+    return new Error(
+      `Authentication failed. Check your API key.${serverSuffix}`
+    );
+  }
+  if (effectiveStatus === 429) {
+    return new Error(
+      `Rate limit exceeded. Wait a moment before retrying.${serverSuffix}`
+    );
+  }
+
+  // Non-JSON plain-text error body (e.g., the reviewsAnalysis endpoint returning
+  // "You do not have permission to access this resource.")
+  if (parsed === null && typeof errorBody === 'string' && errorBody.trim()) {
+    return new Error(
+      `Local Falcon API error (status ${status}): ${errorBody.trim().slice(0, 500)}`
+    );
+  }
+
+  return new Error(`Local Falcon API error: ${status}${serverSuffix}`);
+}
+
+// Unwraps LF.api's standard {code, success, message, parameters, data, field_mask_warnings}
+// wrapper down to its `data` payload, AND preserves field_mask_warnings.exceptions[] as
+// a _warnings string array attached to the returned result. Call sites that used to do
+// `return data.data` (silently discarding the warnings siblings) should use this helper.
+//
+// Handling rules:
+//   - When response.data is missing, falls back to returning `response` itself, matching
+//     the defensive `data?.data ?? data` pattern used in several fetch functions.
+//   - When no warnings are present, returns the inner data unchanged (no _warnings key,
+//     no extra noise).
+//   - When warnings are present and inner is an object, spreads inner and adds
+//     _warnings as a sibling.
+//   - When warnings are present and inner is an array, wraps into { items, _warnings }
+//     (shape-changing, but no current call site returns a bare array to agents, so this
+//     only fires in unusual scenarios).
+//   - When warnings are present and inner is a scalar or undefined, wraps into
+//     { value, _warnings }.
+//   - Each raw path (e.g., "reports.fake.name") is humanized to
+//     "Unknown field in fieldmask: <path>" so agents read it without knowing the
+//     wrapper shape.
+export function unwrapWithWarnings(response: any): any {
+  // Use `'data' in response` (not `?.data ?? response`) so that an explicit
+  // null data value passes through as null instead of falling back to the wrapper.
+  const hasWrapper =
+    response !== null && typeof response === 'object' && 'data' in response;
+  const inner = hasWrapper ? response.data : response;
+  const exceptions: string[] | undefined =
+    response?.field_mask_warnings?.exceptions;
+
+  if (!exceptions?.length) return inner;
+
+  const warnings = exceptions.map((field) => `Unknown field in fieldmask: ${field}`);
+
+  if (Array.isArray(inner)) {
+    return { items: inner, _warnings: warnings };
+  }
+  if (inner !== null && typeof inner === 'object') {
+    return { ...inner, _warnings: warnings };
+  }
+  return { value: inner, _warnings: warnings };
+}
+
 // Rate limiting implementation
 class RateLimiter {
   maxRequests: number;
@@ -368,31 +486,32 @@ export async function fetchLocalFalconReports(apiKey: string, limit: string, nex
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // When fieldmask is used, the API returns the standard structure with filtered fields
     if (fieldmask) {
-      if (data?.data?.reports) {
+      if (unwrapped?.reports) {
         return {
-          ...data.data,
-          reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+          ...unwrapped,
+          reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
         };
       }
-      // Fallback: return whatever the API gave us
-      return data?.data ?? data;
+      // Fallback: return whatever the unwrap gave us (preserves _warnings if present)
+      return unwrapped;
     }
 
     // Validate response structure before processing
-    if (!data || !data.data || !data.data.reports) {
+    if (!unwrapped || !unwrapped.reports) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
     return {
-      ...data.data,
-      reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+      ...unwrapped,
+      reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
     };
   });
 }
@@ -429,30 +548,31 @@ export async function fetchLocalFalconTrendReports(apiKey: string, limit: string
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // When fieldmask is used, the API returns the standard structure with filtered fields
     if (fieldmask) {
-      if (data?.data?.reports) {
+      if (unwrapped?.reports) {
         return {
-          ...data.data,
-          reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+          ...unwrapped,
+          reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
         };
       }
-      return data?.data ?? data;
+      return unwrapped;
     }
 
     // Validate response structure
-    if (!data || !data.data || !data.data.reports) {
+    if (!unwrapped || !unwrapped.reports) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
     return {
-      ...data.data,
-      reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+      ...unwrapped,
+      reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
     };
   });
 }
@@ -491,7 +611,7 @@ export async function fetchLocalFalconAutoScans(apiKey: string, nextToken?: stri
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -530,34 +650,34 @@ export async function fetchLocalFalconLocationReports(apiKey: string, limit: str
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // When fieldmask is used, the API returns the standard structure with filtered fields
     if (fieldmask) {
-      if (data?.data?.reports) {
+      if (unwrapped?.reports) {
         return {
-          ...data.data,
-          reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+          ...unwrapped,
+          reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
         };
       }
-      return data?.data ?? data;
+      return unwrapped;
     }
 
     // Validate response
-    if (!data || !data.data || !data.data.reports) {
+    if (!unwrapped || !unwrapped.reports) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
-    const report = data.data;
-    const limitNum = parseInt(limit) || report.reports.length;
+    const limitNum = parseInt(limit) || unwrapped.reports.length;
 
-    return {
-      next_token: report.next_token,
-      ai_analysis: report.ai_analysis,
-      reports: report.reports.slice(0, limitNum).map((report: any) => {
+    const out: any = {
+      next_token: unwrapped.next_token,
+      ai_analysis: unwrapped.ai_analysis,
+      reports: unwrapped.reports.slice(0, limitNum).map((report: any) => {
         return {
           report_key: report.report_key,
           last_date: report.last_date,
@@ -570,6 +690,8 @@ export async function fetchLocalFalconLocationReports(apiKey: string, limit: str
         };
       }),
     };
+    if (unwrapped._warnings) out._warnings = unwrapped._warnings;
+    return out;
   });
 }
 
@@ -596,7 +718,7 @@ export async function fetchAllLocalFalconLocations(apiKey: string, query?: strin
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -624,7 +746,7 @@ export async function fetchLocalFalconLocationReport(apiKey: string, reportKey: 
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -657,32 +779,34 @@ export async function fetchLocalFalconReport(apiKey: string, reportKey: string, 
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // Handle 202 Accepted — scan report is still processing
     if (res.status === 202) {
       return {
-        ...(data?.data ?? data),
+        ...unwrapped,
         _mcp_note: "This scan report is still processing. Wait 30-60 seconds and call getLocalFalconReport again with the same report_key."
       };
     }
 
     try {
       // Validate the response
-      if (!data || !data.data) {
+      if (!unwrapped) {
         throw new Error('Invalid response format from Local Falcon API');
       }
 
       // Strip data_points by default — too large for LLM context windows
       // (e.g. 81 grid points × 20 results each). Preserve when fieldmask explicitly requests them.
+      // _warnings (if present from unwrapWithWarnings) passes through either branch.
       const wantsDataPoints = fieldmask && fieldmask.includes('data_points');
       if (wantsDataPoints) {
-        return data.data;
+        return unwrapped;
       }
-      const { data_points, ...cleanData } = data.data;
+      const { data_points, ...cleanData } = unwrapped;
       return cleanData;
     } catch (err) {
       throw new Error(`Failed to parse report data: ${err}`);
@@ -719,16 +843,17 @@ export async function fetchLocalFalconTrendReport(apiKey: string, reportKey: str
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
-    if (!data || !data.data) {
+    if (!unwrapped) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
-    const report = data.data;
+    const report = unwrapped;
 
     // Always clean up the response — strip heavy nested data regardless of fieldmask.
     // The scans array and locations array contain data_points that are too large for LLM context.
@@ -824,32 +949,33 @@ export async function fetchLocalFalconKeywordReports(apiKey: string, limit: stri
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // When fieldmask is used, the API returns the standard structure with filtered fields
     if (fieldmask) {
-      if (data?.data?.reports) {
+      if (unwrapped?.reports) {
         return {
-          ...data.data,
-          reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+          ...unwrapped,
+          reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
         };
       }
-      return data?.data ?? data;
+      return unwrapped;
     }
 
     // Validate the response
-    if (!data || !data.data || !data.data.reports) {
+    if (!unwrapped || !unwrapped.reports) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
-    const limitNum = parseInt(limit) || data.data.reports.length;
+    const limitNum = parseInt(limit) || unwrapped.reports.length;
 
     return {
-      ...data.data,
-      reports: data.data.reports.slice(0, limitNum).map((report: any) => {
+      ...unwrapped,
+      reports: unwrapped.reports.slice(0, limitNum).map((report: any) => {
         // Remove unnecessary fields to save bandwidth
         const { last_timestamp, looker_last_date, scan_count, pdf, ...cleanReport } = report;
         return cleanReport;
@@ -884,7 +1010,7 @@ export async function fetchLocalFalconKeywordReport(apiKey: string, reportKey: s
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -921,7 +1047,7 @@ export async function fetchLocalFalconGrid(apiKey: string, lat?: string, lng?: s
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -955,7 +1081,7 @@ export async function fetchLocalFalconGoogleBusinessLocations(apiKey: string, ne
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -989,7 +1115,7 @@ export async function fetchLocalFalconRankingAtCoordinate(apiKey: string, lat: s
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -1023,7 +1149,7 @@ export async function fetchLocalFalconKeywordAtCoordinate(apiKey: string, lat: s
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -1082,7 +1208,7 @@ export async function fetchLocalFalconFullGridSearch(
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const responseData = await safeParseJson(res);
@@ -1146,32 +1272,33 @@ export async function fetchLocalFalconCompetitorReports(apiKey: string, limit: s
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // When fieldmask is used, the API returns the standard structure with filtered fields
     if (fieldmask) {
-      if (data?.data?.reports) {
+      if (unwrapped?.reports) {
         return {
-          ...data.data,
-          reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+          ...unwrapped,
+          reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
         };
       }
-      return data?.data ?? data;
+      return unwrapped;
     }
 
     // Validate the response
-    if (!data || !data.data || !data.data.reports) {
+    if (!unwrapped || !unwrapped.reports) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
-    const limitNum = parseInt(limit) || data.data.reports.length;
+    const limitNum = parseInt(limit) || unwrapped.reports.length;
 
     return {
-      ...data.data,
-      reports: data.data.reports.slice(0, limitNum).map((report: any) => {
+      ...unwrapped,
+      reports: unwrapped.reports.slice(0, limitNum).map((report: any) => {
         // Remove unnecessary fields to save bandwidth
         const {
           data_points,
@@ -1214,17 +1341,18 @@ export async function fetchLocalFalconCompetitorReport(apiKey: string, reportKey
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     try {
-      if (!data || !data.data) {
+      if (!unwrapped) {
         throw new Error('Invalid response format from Local Falcon API');
       }
 
-      const reportData = data.data;
+      const reportData = unwrapped;
 
       // Strip data_points from each business by default — too large for LLM context
       // (e.g. 31 competitors × 9 grid points × 20 results each).
@@ -1277,32 +1405,33 @@ export async function fetchLocalFalconCampaignReports(apiKey: string, limit: str
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // When fieldmask is used, the API returns the standard structure with filtered fields
     if (fieldmask) {
-      if (data?.data?.reports) {
+      if (unwrapped?.reports) {
         return {
-          ...data.data,
-          reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+          ...unwrapped,
+          reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
         };
       }
-      return data?.data ?? data;
+      return unwrapped;
     }
 
     // Validate the response
-    if (!data || !data.data || !data.data.reports) {
+    if (!unwrapped || !unwrapped.reports) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
-    const limitNum = parseInt(limit) || data.data.reports.length;
+    const limitNum = parseInt(limit) || unwrapped.reports.length;
 
     return {
-      ...data.data,
-      reports: data.data.reports.slice(0, limitNum).map((report: any) => {
+      ...unwrapped,
+      reports: unwrapped.reports.slice(0, limitNum).map((report: any) => {
         // Remove only truly unnecessary fields
         const {
           data_points,
@@ -1342,7 +1471,7 @@ export async function fetchLocalFalconCampaignReport(apiKey: string, reportKey: 
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -1378,32 +1507,33 @@ export async function fetchLocalFalconGuardReports(apiKey: string, limit: string
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     const data = await safeParseJson(res);
+    const unwrapped = unwrapWithWarnings(data);
 
     // When fieldmask is used, the API returns the standard structure with filtered fields
     if (fieldmask) {
-      if (data?.data?.reports) {
+      if (unwrapped?.reports) {
         return {
-          ...data.data,
-          reports: data.data.reports.slice(0, parseInt(limit) || data.data.reports.length)
+          ...unwrapped,
+          reports: unwrapped.reports.slice(0, parseInt(limit) || unwrapped.reports.length)
         };
       }
-      return data?.data ?? data;
+      return unwrapped;
     }
 
     // Validate the response
-    if (!data || !data.data || !data.data.reports) {
+    if (!unwrapped || !unwrapped.reports) {
       throw new Error('Invalid response format from Local Falcon API');
     }
 
-    const limitNum = parseInt(limit) || data.data.reports.length;
+    const limitNum = parseInt(limit) || unwrapped.reports.length;
 
     return {
-      ...data.data,
-      reports: data.data.reports.slice(0, limitNum)
+      ...unwrapped,
+      reports: unwrapped.reports.slice(0, limitNum)
     };
   });
 }
@@ -1431,7 +1561,7 @@ export async function fetchLocalFalconGuardReport(apiKey: string, placeId: strin
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -1561,7 +1691,7 @@ export async function runLocalFalconScan(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     // HTTP 202 — scan still processing after server's eager wait. report_key is present
@@ -1616,7 +1746,7 @@ export async function searchForLocalFalconBusinessLocation(
     const data = await safeParseJson(response);
     
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1668,7 +1798,7 @@ export async function saveLocalFalconBusinessLocationToAccount(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1710,7 +1840,7 @@ export async function fetchLocalFalconAccountInfo(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1744,7 +1874,7 @@ export async function addLocationsToFalconGuard(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1787,7 +1917,7 @@ export async function pauseFalconGuardProtection(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1830,7 +1960,7 @@ export async function resumeFalconGuardProtection(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1873,7 +2003,7 @@ export async function removeFalconGuardProtection(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1941,7 +2071,7 @@ export async function createLocalFalconCampaign(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -1999,7 +2129,7 @@ export async function runLocalFalconCampaign(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -2039,7 +2169,7 @@ export async function pauseLocalFalconCampaign(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -2085,7 +2215,7 @@ export async function resumeLocalFalconCampaign(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -2125,7 +2255,7 @@ export async function reactivateLocalFalconCampaign(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -2179,7 +2309,7 @@ export async function fetchLocalFalconReviewsAnalysisReports(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -2221,7 +2351,7 @@ export async function fetchLocalFalconReviewsAnalysisReport(
     const data = await safeParseJson(response);
 
     if (!response.ok) {
-      throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      throw parseApiError(response.status, data);
     }
 
     return data;
@@ -2265,7 +2395,7 @@ export async function searchLocalFalconKnowledgeBase(
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);
@@ -2295,7 +2425,7 @@ export async function getLocalFalconKnowledgeBaseArticle(
 
     if (!res.ok) {
       const errorText = await res.text();
-      throw new Error(`Local Falcon API error: ${res.status} ${res.statusText} - ${errorText}`);
+      throw parseApiError(res.status, errorText);
     }
 
     return await safeParseJson(res);

--- a/localfalcon.ts
+++ b/localfalcon.ts
@@ -1438,6 +1438,54 @@ export async function fetchLocalFalconGuardReport(apiKey: string, placeId: strin
   });
 }
 
+type ScanSubmissionParams = {
+  placeId: string;
+  keyword: string;
+  gridSize: string;
+  platform: string;
+};
+
+// Shape the MCP return for the HTTP 202 "scan is processing" branch. When the server
+// accepts a scan under eager mode but can't finish within its 20s eager budget, it
+// returns 202 with data.report_key populated so the agent can poll. Mirrors the 202
+// pattern in fetchLocalFalconReport().
+export function buildEagerPendingResponse(
+  data: any,
+  params: ScanSubmissionParams
+): any {
+  const reportKey = data?.data?.report_key;
+  const status = data?.data?.status ?? 'pending';
+  return {
+    success: true,
+    message: reportKey
+      ? `Scan submitted successfully and is processing. Report key: ${reportKey}. Poll getLocalFalconReport with this key to check status — it will return HTTP 202 with a pending note until the scan completes.`
+      : "Scan submitted successfully and is processing. Poll listLocalFalconScanReports with the same placeId to find the report_key.",
+    report_key: reportKey,
+    status,
+    place_id: params.placeId,
+    keyword: params.keyword,
+    grid_size: params.gridSize,
+    platform: params.platform,
+    _mcp_note: "The scan is queued and processing. Call getLocalFalconReport with this report_key to poll status. Do NOT retry runLocalFalconScan — retrying consumes additional credits."
+  };
+}
+
+// Shape the MCP return for the network-timeout fallback. Shouldn't fire under normal
+// conditions (SCAN_SUBMIT_TIMEOUT_MS > server's 20s eager wait), but can happen under
+// network congestion. report_key isn't available here; agent must recover by listing
+// recent scans.
+export function buildScanTimeoutFallback(params: ScanSubmissionParams): any {
+  return {
+    success: true,
+    message: "Scan submitted successfully but the report key could not be captured due to a network timeout. Check your recent scans via listLocalFalconScanReports in a moment to find it.",
+    place_id: params.placeId,
+    keyword: params.keyword,
+    grid_size: params.gridSize,
+    platform: params.platform,
+    _mcp_note: "The scan is running. Use listLocalFalconScanReports with the same placeId to find the submitted report. Do NOT retry runLocalFalconScan — retrying consumes additional credits."
+  };
+}
+
 /**
  * Runs a scan at the specified coordinate point and gets ranking data for a specified business.
  * @param {string} apiKey - Your Local Falcon API key
@@ -1478,12 +1526,17 @@ export async function runLocalFalconScan(
     form.append('measurement', measurement);
     form.append('platform', platform);
     form.append('ai_analysis', aiAnalysis.toString());
+    // eager=1 tells LF.api's methods/v2/run-scan/method.php runtime_check() to cap
+    // its server-side wait at 20s instead of 360s. If the scan completes in <20s we
+    // get HTTP 200 with the full report; otherwise HTTP 202 with data.report_key
+    // populated so the agent can poll via getLocalFalconReport. Resolves Bug #2
+    // (submission previously returned no report_key on timeout).
+    form.append('eager', '1');
 
-    // Scan submission strategy:
-    // The Local Falcon API blocks until the scan completes, which can take seconds to 10+ minutes.
-    // We use a short timeout to catch auth/validation errors, then treat a timeout as a SUCCESSFUL
-    // submission — the scan was queued and is processing. No retries (would consume extra credits).
-    const SCAN_SUBMIT_TIMEOUT_MS = 15000; // 15s — enough to catch errors, not meant to wait for completion
+    // Server's eager budget is 20s (runtime_check in LF.api). 25s keeps a 5s margin so
+    // the MCP's timeout outlasts the server — we capture the 202-with-report_key
+    // response instead of aborting into the network-timeout fallback path.
+    const SCAN_SUBMIT_TIMEOUT_MS = 25_000;
 
     let response: any;
     try {
@@ -1496,28 +1549,29 @@ export async function runLocalFalconScan(
         SCAN_SUBMIT_TIMEOUT_MS
       );
     } catch (error) {
-      // Timeout = scan was submitted and is processing (this is expected, not an error)
+      // MCP-side timeout before server responded — shouldn't happen with 25s > 20s
+      // eager budget, but possible under network congestion. report_key is unreachable
+      // from here; agent recovers via listings.
       if (isTimeoutError(error)) {
-        return {
-          success: true,
-          message: "Scan submitted successfully and is now processing. Scans typically take 30 seconds to several minutes to complete depending on grid size and queue load.",
-          place_id: placeId,
-          keyword: keyword,
-          grid_size: gridSize,
-          platform: platform,
-          _mcp_note: "The scan is running. Use listLocalFalconScanReports with the same placeId to find the completed report. Do NOT retry runLocalFalconScan — the scan is already queued and retrying would consume additional credits. If the report does not appear after 4-5 polling attempts, inform the user that their scan is still processing and suggest they check https://www.localfalcon.com/reports for results, or ask again in a few minutes."
-        };
+        return buildScanTimeoutFallback({ placeId, keyword, gridSize, platform });
       }
       throw error;
     }
 
-    // If the API responded within 15s, the scan completed quickly — return the full result
     const data = await safeParseJson(response);
 
     if (!response.ok) {
       throw new Error(data.message || `HTTP error! status: ${response.status}`);
     }
 
+    // HTTP 202 — scan still processing after server's eager wait. report_key is present
+    // in data.data so the agent can poll getLocalFalconReport until completion.
+    if (response.status === 202) {
+      return buildEagerPendingResponse(data, { placeId, keyword, gridSize, platform });
+    }
+
+    // HTTP 200 — scan completed within server's 20s eager budget. Full report is in
+    // the response body with report_key inside data.
     return data;
   } catch (error) {
     console.error('Error running scan:', error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@local-falcon/mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "An MCP server for the Local Falcon API.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ai-visibility"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "bun test",
     "build:ui": "UI_ENTRY=geogrid-heatmap vite build --config vite.ui.config.ts",
     "start": "bun run index.ts",
     "start:sse": "bun run index.ts sse",

--- a/server.ts
+++ b/server.ts
@@ -356,7 +356,7 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
       gridSize: z.enum(['3', '5', '7', '9', '11', '13', '15', '17', '19', '21']).nullish().describe("Filter only for specific grid sizes. Expects 3, 5, 7, 9, 11, 13, 15, 17, 19, or 21."), 
       campaignKey: z.string().nullish().describe("Filter only results for a specific campaign using the campaign_key."), 
       platform: z.enum(['google', 'apple', 'gaio', 'chatgpt','gemini','grok']).nullish().describe("Filter only results for a specific platform."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Scan Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ nextToken, startDate, endDate, placeId, keyword, gridSize, campaignKey, platform, fieldmask }, ctx) => {
@@ -401,8 +401,8 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
 
 Requires a report_key from listLocalFalconScanReports. Cannot create new reports — use runLocalFalconScan for that.`,
       inputSchema: {
-        reportKey: z.string().describe("The report key of the scan report."),
-        fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+        reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report key of the scan report. 15-character lowercase hex string (e.g., 'ad412d968a25a84')."),
+        fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
       },
       title: "Get Scan Report",
       annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
@@ -450,7 +450,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       nextToken: z.string().nullish().describe("Pagination token for additional results."),
       query: z.string().describe("The query to search for."),
       near: z.string().nullish().describe("Narrow results by location. City, state, country, etc."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Search Google Business Listings", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ nextToken, query, near, fieldmask }, ctx) => {
@@ -499,7 +499,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       placeId: z.string().nullish().describe("Filter only results for specific Google Place ID. Supports multiple Google Place IDs, seperated by commas."),
       runDate: z.string().date().nullish().describe("Filter only results for a specific Campaign run date. Expects date formatted as YYYY-MM-DD (ISO 8601). Defaults to the last report run."),
       nextToken: z.string().nullish().describe("This parameter is used to get the next 'page' of results. The value used with the parameter is provided from a previous response by this endpoint if more 'pages' of results exist."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Campaign Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ startDate, endDate, placeId, runDate, nextToken, fieldmask }, ctx) => {
@@ -518,9 +518,9 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
     "getLocalFalconCampaignReport",
     `Retrieves a specific campaign report with full details: aggregated ARP, ATRP, SoLV metrics, individual scan results, performance breakdowns by keyword and location, and scheduling info. Use the 'run' parameter (MM/DD/YYYY) to retrieve a specific historical run — defaults to the latest run. STRONGLY RECOMMEND fieldmask — campaign reports with many locations/keywords can be very large. Recommended fieldmask for overview: "report_key,name,status,locations,keywords,arp,atrp,solv,frequency,last_run,next_run,scans,grid_size,radius,measurement". Note: \`arp_move\`, \`atrp_move\`, \`solv_move\` delta fields appear on list-endpoint items (listLocalFalconCampaignReports) but are not present on this single-get endpoint. Get the report_key from listLocalFalconCampaignReports.`,
     {
-      reportKey: z.string().describe("The report_key of the Campaign Report you wish to retrieve."),
+      reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report_key of the Campaign Report you wish to retrieve. 15-character lowercase hex string."),
       run: z.string().nullish().describe("Optional specific campaign run date to retrieve (MM/DD/YYYY). Defaults to latest run."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Get Campaign Report", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ reportKey, run, fieldmask }, ctx) => {
@@ -669,7 +669,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       frequency: z.enum(['one_time', 'daily', 'weekly', 'two_weeks', 'three_weeks', 'four_weeks', 'monthly']).nullish().describe("Filter by analysis frequency."),
       limit: z.number().min(1).max(100).nullish().describe("Number of results to retrieve (1-100). Defaults to 10."),
       nextToken: z.string().nullish().describe("Pagination token for retrieving the next page of results."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Reviews Analysis Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ reviewsKey, placeId, frequency, limit, nextToken, fieldmask }, ctx) => {
@@ -695,8 +695,8 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
     "getLocalFalconReviewsAnalysisReport",
     "Retrieves a specific Reviews Analysis report with full metrics: Review Volume Score (RVS), Review Quality Score (RQS), review velocity, freshness, total reviews, rating analysis, response rates, Local Guide reviews, photo reviews, and sentiment/topic analysis. Includes competitor comparison data if competitors were configured. Use fieldmask to control response size — review reports can be very large. Get the report key from listLocalFalconReviewsAnalysisReports.",
     {
-      reportKey: z.string().describe("The key of the Reviews Analysis report you wish to retrieve."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The key of the Reviews Analysis report you wish to retrieve. 15-character lowercase hex string."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Get Reviews Analysis Report", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ reportKey, fieldmask }, ctx) => {
@@ -718,7 +718,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       endDate: z.string().date().nullish().describe("Upper limit date you wish to retrieve. Expects date formatted as YYYY-MM-DD (ISO 8601)."),
       status: z.enum(['protected', 'paused']).nullish().describe("Filter results by status: protected or paused."),
       nextToken: z.string().nullish().describe("This parameter is used to get the next 'page' of results. The value used with the parameter is provided from a previous response by this endpoint if more 'pages' of results exist."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Falcon Guard Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ startDate, endDate, status, nextToken, fieldmask }, ctx) => {
@@ -737,10 +737,10 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
     "getLocalFalconGuardReport",
     "Retrieves a Falcon Guard report IF it exists for the location given a place_id. Shows Google Business Profile monitoring data. OAuth-connected locations include full metrics (calls, clicks, directions) plus historical changes. Manually added locations only show historical GBP changes. Returns an error if Guard is not enabled for this location.",
     {
-      placeId: z.string().describe("The place_id of the Falcon Guard Report you wish to retrieve."),
+      placeId: z.string().min(1).describe("The place_id of the Falcon Guard Report you wish to retrieve. Cannot be empty. Place IDs span multiple formats (Google 'ChIJ...', Apple, brand-only); no regex constraint applied."),
       startDate: z.string().nullish().describe("A lower limit date for changes and metrics. Expects date formatted as MM/DD/YYYY."),
       endDate: z.string().nullish().describe("Upper limit date for changes and metrics. Expects date formatted as MM/DD/YYYY."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Get Falcon Guard Report", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ placeId, startDate, endDate, fieldmask }, ctx) => {
@@ -848,7 +848,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       startDate: z.string().nullish().describe("A lower limit date of a scan report you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       endDate: z.string().nullish().describe("Upper limit date of a scan report you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       platform: z.enum(['google', 'apple', 'gaio', 'chatgpt','gemini','grok']).nullish().describe("Filter only results for a specific platform."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Trend Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ nextToken, placeId, keyword, startDate, endDate, platform, fieldmask }, ctx) => {
@@ -867,8 +867,8 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
     "getLocalFalconTrendReport",
     `Retrieves a specific trend report showing historical ARP, ATRP, and SoLV changes across multiple scan dates for one location + one keyword. Returns: scans array (historical snapshots with date, ARP, ATRP, SoLV, grid images per scan), locations array (competitor leaderboard with aggregated metrics across all scans), location object (full GBP profile of the target business), and top-level metadata (keyword, grid config, PDF link). Heavy nested data (data_points, per-scan locations) is automatically stripped to save context. Get the report_key from listLocalFalconTrendReports.`,
     {
-      reportKey: z.string().describe("The report key of the trend report."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report key of the trend report. 15-character lowercase hex string."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Get Trend Report", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ reportKey, fieldmask }, ctx) => {
@@ -894,7 +894,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       frequency: z.enum(["one-time", "daily", "weekly", "biweekly", "monthly"]).nullish().describe("The frequency of the scan."),
       status: z.string().nullish().describe("The status of the scan."),
       platform: z.enum(['google', 'apple', 'gaio', 'chatgpt','gemini','grok']).nullish().describe("The platform of the scan."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Scheduled Auto-Scans", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ nextToken, placeId, keyword, gridSize, frequency, status, platform, fieldmask }, ctx) => {
@@ -917,7 +917,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       startDate: z.string().nullish().describe("A lower limit date of a scan report you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       endDate: z.string().nullish().describe("Upper limit date of a scan report you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       nextToken: z.string().nullish().describe("Pagination token for additional results."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Location Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ placeId, keyword, startDate, endDate, nextToken, fieldmask }, ctx) => {
@@ -936,8 +936,8 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
     "getLocalFalconLocationReport",
     "Retrieves a specific location report aggregating scan data across multiple keywords for one business location. Shows which keywords perform best/worst for that location. Use fieldmask to control response size. Get the report_key from listLocalFalconLocationReports.",
     {
-      reportKey: z.string().describe("The report key of the location report."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report key of the location report. 15-character lowercase hex string."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Get Location Report", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ reportKey, fieldmask }, ctx) => {
@@ -959,7 +959,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       keyword: z.string().nullish().describe("The keyword to search for."),
       startDate: z.string().nullish().describe("A lower limit date of a scan report you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
       endDate: z.string().nullish().describe("Upper limit date of a scan report you wish to retrieve. Expects date formatted as MM/DD/YYYY."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Keyword Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ nextToken, keyword, startDate, endDate, fieldmask }, ctx) => {
@@ -978,8 +978,8 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
     "getLocalFalconKeywordReport",
     "Retrieves a specific keyword report aggregating scan data across multiple locations for one keyword. Shows which locations perform best/worst for that keyword. Use fieldmask to control response size. Get the report_key from listLocalFalconKeywordReports.",
     {
-      reportKey: z.string(),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report_key of the keyword report. 15-character lowercase hex string."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Get Keyword Report", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ reportKey, fieldmask }, ctx) => {
@@ -1003,7 +1003,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
       keyword: z.string().nullish().describe("Filter only results similar to specified keyword (loose match)."),
       gridSize: z.enum(['3', '5', '7', '9', '11', '13', '15']).nullish().describe("Filter only for specific grid sizes. Expects 3, 5, 7, 9, 11, 13, or 15."),
       nextToken: z.string().nullish().describe("This parameter is used to get the next 'page' of results. The value used with the parameter is provided from a previous response by this endpoint if more 'pages' of results exist."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "List Competitor Reports", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ startDate, endDate, placeId, keyword, gridSize, nextToken, fieldmask }, ctx) => {
@@ -1028,8 +1028,8 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
 
 Available for all platform types. Get the report_key from getLocalFalconCompetitorReports.`,
     {
-      reportKey: z.string().describe("The report_key of the Competitor Report you wish to retrieve."),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report_key of the Competitor Report you wish to retrieve. 15-character lowercase hex string."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "Get Competitor Report", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ reportKey, fieldmask }, ctx) => {
@@ -1183,7 +1183,7 @@ Available for all platform types. Get the report_key from getLocalFalconCompetit
     "Retrieves Local Falcon account information. Returns user, credit package, subscription, and credits.",
     {
       returnField: z.enum(['user', 'credit package', 'subscription', 'credits']).nullish().describe("Optional specific return information"),
-      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
+      fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
     },
     { title: "View Account Information", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ returnField, fieldmask }, ctx) => {
@@ -1239,7 +1239,7 @@ Available for all platform types. Get the report_key from getLocalFalconCompetit
     "getLocalFalconKnowledgeBaseArticle",
     "Retrieves the complete content of a specific Local Falcon Knowledge Base article, including full step-by-step instructions in markdown format. Use this AFTER searchLocalFalconKnowledgeBase to get the full guide for a specific article. If the user references an article by number (e.g. 'KB70', 'article 70', '#70'), strip any prefix and pass just the numeric ID. This is the tool that gives you the actual detailed instructions, walkthroughs, and explanations — the search tool only returns summaries.",
     {
-      articleId: z.string().describe("The numeric ID of the Knowledge Base article to retrieve (e.g. '70'). If the user says 'KB70' or 'article 70', just pass '70'."),
+      articleId: z.string().min(1).regex(/^(KB)?\d+$/i, "articleId must be numeric (e.g. '70') or KB-prefixed (e.g. 'KB70')").describe("The numeric ID of the Knowledge Base article to retrieve (e.g. '70'). If the user says 'KB70' or 'article 70', just pass '70'."),
     },
     { title: "Get Knowledge Base Article", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async ({ articleId }, ctx) => {

--- a/server.ts
+++ b/server.ts
@@ -693,7 +693,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
   // Get specific Reviews Analysis Report
   server.tool(
     "getLocalFalconReviewsAnalysisReport",
-    "Retrieves a specific Reviews Analysis report with full metrics: Review Volume Score (RVS), Review Quality Score (RQS), review velocity, freshness, total reviews, rating analysis, response rates, Local Guide reviews, photo reviews, and sentiment/topic analysis. Includes competitor comparison data if competitors were configured. Use fieldmask to control response size — review reports can be very large. Get the report key from listLocalFalconReviewsAnalysisReports.",
+    "Retrieves a specific Reviews Analysis report with full metrics: Review Volume Score (RVS), Review Quality Score (RQS), review velocity, freshness, total reviews, rating analysis, response rates, Local Guide reviews, photo reviews, and sentiment/topic analysis. Includes competitor comparison data if competitors were configured. STRONGLY RECOMMEND fieldmask — review reports can exceed 100KB given sentiment/topic breakdowns across up to 1M reviews. Recommended fieldmask for overview: 'reviews_key,name,review_date,locations,frequency,statistics.metrics.primaryBusiness'. For competitor comparison add 'statistics.metrics.competitors'; for sentiment detail add 'statistics.sentiment'. Get the report key from listLocalFalconReviewsAnalysisReports.",
     {
       reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The key of the Reviews Analysis report you wish to retrieve. 15-character lowercase hex string."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
@@ -865,7 +865,15 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
   // Get a Specific Trend Report
   server.tool(
     "getLocalFalconTrendReport",
-    `Retrieves a specific trend report showing historical ARP, ATRP, and SoLV changes across multiple scan dates for one location + one keyword. Returns: scans array (historical snapshots with date, ARP, ATRP, SoLV, grid images per scan), locations array (competitor leaderboard with aggregated metrics across all scans), location object (full GBP profile of the target business), and top-level metadata (keyword, grid config, PDF link). Heavy nested data (data_points, per-scan locations) is automatically stripped to save context. Get the report_key from listLocalFalconTrendReports.`,
+    `Retrieves a specific trend report showing historical ARP, ATRP, and SoLV changes across multiple scan dates for one location + one keyword. Returns: scans array (historical snapshots with date, ARP, ATRP, SoLV, grid images per scan), locations array (competitor leaderboard with aggregated metrics across all scans), location object (full GBP profile of the target business), and top-level metadata (keyword, grid config, PDF link). Heavy nested data (data_points, per-scan locations) is automatically stripped to save context.
+
+**STRONGLY RECOMMEND** fieldmask — trend reports with many historical scans can grow large (scans[] array scales with snapshot count).
+
+**Recommended fieldmask (Maps-platform trend reports):** "last_date,keyword,location.name,scan_count,scans.*.date,scans.*.arp,scans.*.atrp,scans.*.solv"
+
+**Recommended fieldmask (AI-platform trend reports):** swap \`scans.*.solv\` for \`scans.*.saiv\`.
+
+Get the report_key from listLocalFalconTrendReports.`,
     {
       reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report key of the trend report. 15-character lowercase hex string."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
@@ -934,7 +942,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
   // Get a Specific Location Report
   server.tool(
     "getLocalFalconLocationReport",
-    "Retrieves a specific location report aggregating scan data across multiple keywords for one business location. Shows which keywords perform best/worst for that location. Use fieldmask to control response size. Get the report_key from listLocalFalconLocationReports.",
+    "Retrieves a specific location report aggregating scan data across multiple keywords for one business location. Shows which keywords perform best/worst for that location. STRONGLY RECOMMEND fieldmask — location reports aggregating many keywords can grow large. Recommended fieldmask: 'report_key,last_date,place_id,location.name,location.address,keyword_count,keywords.*.keyword,keywords.*.arp,keywords.*.atrp,keywords.*.solv'. Get the report_key from listLocalFalconLocationReports.",
     {
       reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report key of the location report. 15-character lowercase hex string."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),
@@ -976,7 +984,7 @@ Requires a report_key from listLocalFalconScanReports. Cannot create new reports
   // Get specific Keyword Report
   server.tool(
     "getLocalFalconKeywordReport",
-    "Retrieves a specific keyword report aggregating scan data across multiple locations for one keyword. Shows which locations perform best/worst for that keyword. Use fieldmask to control response size. Get the report_key from listLocalFalconKeywordReports.",
+    "Retrieves a specific keyword report aggregating scan data across multiple locations for one keyword. Shows which locations perform best/worst for that keyword. STRONGLY RECOMMEND fieldmask — keyword reports aggregating many locations can grow large. Recommended fieldmask: 'report_key,last_date,keyword,location_count,locations.*.place_id,locations.*.name,locations.*.arp,locations.*.atrp,locations.*.solv'. Get the report_key from listLocalFalconKeywordReports.",
     {
       reportKey: z.string().min(1).regex(/^[a-f0-9]{15}$/, "reportKey must be 15 lowercase hex characters (a-f, 0-9)").describe("The report_key of the keyword report. 15-character lowercase hex string."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Dot notation for nested paths (e.g., 'location.name'). The `.*.` wildcard works on arrays (e.g., 'scans.*.arp' on trend/campaign reports, where scans is an array) AND on dicts of objects (e.g., 'places.*.solv' on scan reports, where places is keyed by place_id with object values). For dicts of scalars like 'rankings.by_arp' (where values are numbers/strings keyed by place_id, not objects), request the whole dict by path alone — `.*.X` returns nothing because scalars can't be descended into. Omit to return all fields. STRONGLY recommended on every call: default responses can exceed 100KB."),

--- a/server.ts
+++ b/server.ts
@@ -109,36 +109,47 @@ Most get* and list* tools accept an optional \`fieldmask\` parameter — a comma
 Scan report — quick overview:
 \`report_key,date,keyword,location.name,location.address,arp,atrp,solv,found_in,grid_size,radius,measurement\`
 
-Scan report — full analysis:
-\`report_key,date,place_id,keyword,location,lat,lng,grid_size,radius,measurement,arp,atrp,solv,found_in,total_competitors,competition_solv,max_solv,opportunity_solv,ai_analysis,image,heatmap\`
+Scan report — full analysis (Maps platforms — google, apple):
+\`report_key,date,place_id,platform,keyword,location,lat,lng,grid_size,radius,measurement,arp,atrp,solv,found_in,unique_competitors,insights.solv_competitors.total,insights.solv_competitors.active,ai_analysis.summary,image,heatmap\`
 
-Scan report list — browsing:
+Scan report — full analysis (AI platforms — chatgpt, gemini, aimode, gaio, grok):
+\`report_key,date,place_id,ai_place_id,platform,keyword,location,lat,lng,grid_size,radius,measurement,arp,atrp,saiv,found_in,unique_competitors,sources,ai_analysis.summary,image,heatmap\`
+
+Scan report list — browsing (polymorphic \`solv\` carries SoLV on Maps, SAIV on AI):
 \`report_key,date,keyword,location.name,arp,atrp,solv,grid_size,platform\`
 
-Trend report — performance tracking:
-\`report_key,last_date,keyword,location.name,scan_count,scans.*.date,scans.*.arp,scans.*.atrp,scans.*.solv\`
+Trend report — performance tracking (use \`scans.*.saiv\` on AI-platform trend reports):
+\`last_date,keyword,location.name,scan_count,scans.*.date,scans.*.arp,scans.*.atrp,scans.*.solv\`
 
-Competitor report — competitive analysis:
+Competitor report — competitive analysis (swap \`businesses.*.solv\` for \`businesses.*.saiv\` on AI-platform scans):
 \`date,keyword,grid_size,radius,businesses.*.name,businesses.*.place_id,businesses.*.arp,businesses.*.atrp,businesses.*.solv,businesses.*.reviews,businesses.*.rating,businesses.*.lat,businesses.*.lng\`
 
-Campaign report list — overview:
+Campaign report list — overview (\`*_move\` fields exist ONLY on list items, not on single-get):
 \`report_key,name,status,locations,keywords,frequency,last_run,next_run,arp,atrp,solv,arp_move,atrp_move,solv_move\`
 
-Campaign report — detailed:
-\`report_key,name,status,locations,keywords,frequency,last_run,next_run,arp,atrp,solv,arp_move,atrp_move,solv_move,scans,grid_size,radius,measurement\`
+Campaign report — detailed (single-get, no \`*_move\` fields here):
+\`report_key,name,status,locations,keywords,frequency,last_run,next_run,arp,atrp,solv,scans,grid_size,radius,measurement\`
 
 Guard report list:
 \`report_key,place_id,location.name,location.address,location.rating,location.reviews,status,date_added,date_last\`
 
 Reviews analysis:
-\`reviews_key,name,date,locations,frequency,statistics.metrics.primaryBusiness\`
+\`reviews_key,name,review_date,locations,frequency,statistics.metrics.primaryBusiness\`
 
 **Fieldmask rules:**
-- Use dot notation for nested fields: \`location.name\`, \`statistics.metrics.primaryBusiness\`
-- Use wildcards for arrays: \`scans.*.arp\`, \`businesses.*.name\`
+- Use dot notation for nested fields: \`location.name\`, \`insights.solv_competitors.total\`
+- Wildcards behave differently depending on what's under the path: see each tool's fieldmask parameter description for the array vs object-dict vs scalar-dict rules
 - Start with the minimal fieldmask for the task, expand only if more data is needed
+- For narrative-only analysis, prefer \`ai_analysis.summary\` over the whole \`ai_analysis\` object (the object also contains structured arrays for problem/success/vulnerable/competitors/citations)
 - When a user asks a specific question (e.g., "what's my ARP?"), use a narrow fieldmask
-- When performing comprehensive analysis, use broader fieldmasks but still exclude raw grid point arrays when aggregate metrics suffice
+- When performing comprehensive analysis, use broader fieldmasks but still exclude raw grid-point arrays when aggregate metrics suffice
+
+**Platform-specific field note:**
+- \`solv\` (Share of Local Voice) → Maps platforms only at the top level of \`getLocalFalconReport\`
+- \`saiv\` (Share of AI Visibility) → AI platforms only at the top level of \`getLocalFalconReport\`
+- \`insights\` object (\`solv_competitors\`, \`osolv\`, \`solv_distance\`) → Maps platforms only
+- \`sources\` array (AI-platform citations) → AI platforms only
+- \`unique_competitors\` → universal on both platform groups
 
 ## TOOL WORKFLOW PATTERNS
 
@@ -195,8 +206,8 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
 
 **Competitive analysis framework:**
 - Compare ARP, SoLV, review count, rating, and primary categories between the target business and top competitors.
-- High Opportunity SoLV with low Competition SoLV = untapped market potential, quick win zone.
-- High Competition SoLV with low Opportunity SoLV = saturated market, consider adjacent keywords or geographic expansion.
+- On Maps scans, \`insights.osolv.yours\` vs \`insights.osolv.top\` gives your SoLV against the top competitor's — a large gap signals the leader has defensible share; a small gap signals the race is open.
+- \`insights.solv_competitors.active\` out of \`.total\` shows how many competitors are actually appearing in the grid vs how many the scan even considered — a low active-to-total ratio suggests opportunity for challengers.
 - Competitors with significantly more reviews or higher ratings often dominate despite proximity disadvantages.
 
 **AI visibility analysis:**
@@ -363,7 +374,32 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   registerAppTool(server,
     "getLocalFalconReport",
     {
-      description: `Retrieves a specific scan report by report_key. Returns full ranking data including ARP, ATRP, SoLV, competitor summary, grid visualization images, and AI analysis text (if enabled). NOTE: The raw data_points array (rank at every grid coordinate) is stripped by default — it is extremely large and rarely needed. ONLY include "data_points" in the fieldmask when the user explicitly asks for per-grid-point data, raw coordinate-level rankings, or a point-by-point breakdown. For general ranking insights, weaknesses, and competitive analysis, use the ai_analysis field instead — it already summarizes grid-level patterns in plain language. Use fieldmask to control response size. Recommended fieldmask for analysis: "report_key,date,place_id,ai_place_id,platform,keyword,location,arp,atrp,solv,found_in,total_competitors,competition_solv,max_solv,opportunity_solv,grid_size,radius,measurement,ai_analysis,image,heatmap". Requires a report_key from listLocalFalconScanReports. Cannot create new reports — use runLocalFalconScan for that.`,
+      description: `Retrieves a specific scan report by report_key. Returns full ranking data, competitor summary, grid visualization images, and AI analysis.
+
+**STRONGLY RECOMMEND** passing a fieldmask on every call. Without one, a single scan report is typically 100-300KB (grid-3 ~112KB, denser markets up to ~300KB), which can overflow LLM context windows. Size hints: \`places\` is the largest single field (~50KB on competitive verticals, 100+ entries each); \`sources\` on AI scans is ~5-15KB (citation list); \`ai_analysis.summary\` alone is ~2KB of HTML-bearing prose and is almost always the right surgical fieldmask for narrative-only analysis. Always strip \`data_points\` (stripped by default) unless per-grid-point data is specifically requested.
+
+**Response shape is platform-specific — pick the recipe that matches your scan's platform:**
+
+- Maps scans (\`platform: google\` or \`apple\`) return top-level \`solv\` plus an \`insights\` object containing:
+  - \`insights.solv_competitors.{total, active}\` — total competitors considered vs how many are actually in the grid
+  - \`insights.osolv.{yours, top}\` — your SoLV vs the top competitor's SoLV (opportunity-gap signal)
+  - \`insights.solv_distance.{yours, average}\` — distance metric around top-3 rankings
+  - Per-place metadata includes rating, reviews, phone, url, categories, store_code
+- AI scans (\`platform: chatgpt\`, \`gemini\`, \`aimode\`, \`gaio\`, \`grok\`) return top-level \`saiv\` instead of \`solv\`, a \`sources\` array (AI-platform citations), \`ai_place_id\`, and \`bps\`. No \`insights\` object on AI. Per-place metadata is leaner (no rating/reviews/phone).
+- \`unique_competitors\` is universal on both platform groups.
+- \`rankings\` keys mirror the top-level metric: \`by_solv\` on Maps, \`by_saiv\` on AI; \`by_arp\` and \`by_atrp\` on both.
+
+**Recommended fieldmask for Maps analysis:**
+\`report_key,date,place_id,platform,keyword,location,lat,lng,grid_size,radius,measurement,arp,atrp,solv,found_in,unique_competitors,insights.solv_competitors.total,insights.solv_competitors.active,ai_analysis.summary,image,heatmap\`
+
+**Recommended fieldmask for AI analysis:**
+\`report_key,date,place_id,ai_place_id,platform,keyword,location,arp,atrp,saiv,found_in,unique_competitors,sources,ai_analysis.summary,image,heatmap\`
+
+**About \`ai_analysis\`:** this is a STRUCTURED OBJECT, not an HTML string. Shape: \`{summary, problem: {major[], minor[]}, success: {major[], minor[]}, vulnerable[], competitors, citations[]}\`. The \`summary\` field is a string (HTML-bearing). If you only need the narrative, fieldmask \`ai_analysis.summary\`; if you need the structured breakdown, fieldmask the whole \`ai_analysis\` object.
+
+**Note on list-vs-get asymmetry:** \`listLocalFalconScanReports\` returns the visibility metric polymorphically as \`solv\` regardless of platform (listing convenience). \`getLocalFalconReport\` is platform-explicit — request \`solv\` on Maps or \`saiv\` on AI; the wrong field will simply be absent from the response.
+
+Requires a report_key from listLocalFalconScanReports. Cannot create new reports — use runLocalFalconScan for that.`,
       inputSchema: {
         reportKey: z.string().describe("The report key of the scan report."),
         fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),
@@ -480,7 +516,7 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   // Get a Specific Campaign Report
   server.tool(
     "getLocalFalconCampaignReport",
-    `Retrieves a specific campaign report with full details: aggregated ARP, ATRP, SoLV metrics, individual scan results, performance breakdowns by keyword and location, and scheduling info. Use the 'run' parameter (MM/DD/YYYY) to retrieve a specific historical run — defaults to the latest run. Use fieldmask to control response size — campaign reports with many locations/keywords can be very large. Recommended fieldmask for overview: "report_key,name,status,locations,keywords,arp,atrp,solv,arp_move,atrp_move,solv_move,frequency,last_run,next_run". Get the report_key from listLocalFalconCampaignReports.`,
+    `Retrieves a specific campaign report with full details: aggregated ARP, ATRP, SoLV metrics, individual scan results, performance breakdowns by keyword and location, and scheduling info. Use the 'run' parameter (MM/DD/YYYY) to retrieve a specific historical run — defaults to the latest run. STRONGLY RECOMMEND fieldmask — campaign reports with many locations/keywords can be very large. Recommended fieldmask for overview: "report_key,name,status,locations,keywords,arp,atrp,solv,frequency,last_run,next_run,scans,grid_size,radius,measurement". Note: \`arp_move\`, \`atrp_move\`, \`solv_move\` delta fields appear on list-endpoint items (listLocalFalconCampaignReports) but are not present on this single-get endpoint. Get the report_key from listLocalFalconCampaignReports.`,
     {
       reportKey: z.string().describe("The report_key of the Campaign Report you wish to retrieve."),
       run: z.string().nullish().describe("Optional specific campaign run date to retrieve (MM/DD/YYYY). Defaults to latest run."),
@@ -626,7 +662,7 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   // List all Reviews Analysis Reports
   server.tool(
     "listLocalFalconReviewsAnalysisReports",
-    `Lists Reviews Analysis reports in the account. These are premium AI-powered review analyses ($19/location) that evaluate up to 1M Google reviews for a target business plus up to 3 competitors. Separate from ranking scan reports. Filter by placeId, frequency, or reviewsKey. Use fieldmask to control returned fields. Recommended fieldmask: "reviews_key,name,date,locations,frequency,statistics.metrics.primaryBusiness". Use getLocalFalconReviewsAnalysisReport with a report key to see full results.`,
+    `Lists Reviews Analysis reports in the account. These are premium AI-powered review analyses ($19/location) that evaluate up to 1M Google reviews for a target business plus up to 3 competitors. Separate from ranking scan reports. Filter by placeId, frequency, or reviewsKey. Use fieldmask to control returned fields. Recommended fieldmask: "reviews_key,name,review_date,locations,frequency,statistics.metrics.primaryBusiness". Use getLocalFalconReviewsAnalysisReport with a report key to see full results.`,
     {
       reviewsKey: z.string().nullish().describe("Filter by parent Reviews Analysis record key to retrieve only reports from that specific configuration."),
       placeId: z.string().nullish().describe("Filter by platform Place ID(s). Supports multiple IDs separated by commas."),
@@ -984,7 +1020,13 @@ Use fieldmasks on each call to keep context manageable. Not all report types wil
   // Get specific Competitor Report
   server.tool(
     "getLocalFalconCompetitorReport",
-    `Retrieves a specific competitor report showing the competitive landscape from a scan. Includes top-ranking businesses with their ARP, ATRP, SoLV (or SAIV for AI scans), review counts, ratings, and geographic coordinates. NOTE: Per-competitor data_points (showing each competitor's rank at every grid coordinate) are stripped by default — they are extremely large. ONLY include "data_points" in the fieldmask when the user explicitly asks for per-grid-point competitive positioning, raw coordinate-level data, or a point-by-point breakdown of where specific competitors rank. For general competitive overviews, the summary metrics (ARP, ATRP, SoLV, rating, reviews) are sufficient. Use fieldmask to control which competitor fields are returned. Recommended fieldmask: "date,keyword,grid_size,radius,businesses.*.name,businesses.*.place_id,businesses.*.arp,businesses.*.atrp,businesses.*.solv,businesses.*.reviews,businesses.*.rating,businesses.*.lat,businesses.*.lng". Available for all platform types including AI scans. Get the report_key from getLocalFalconCompetitorReports.`,
+    `Retrieves a specific competitor report showing the competitive landscape from a scan. Includes top-ranking businesses with their ARP, ATRP, SoLV (Maps) / SAIV (AI), review counts, ratings, and geographic coordinates. NOTE: Per-competitor data_points (showing each competitor's rank at every grid coordinate) are stripped by default — they are extremely large. ONLY include "data_points" in the fieldmask when the user explicitly asks for per-grid-point competitive positioning, raw coordinate-level data, or a point-by-point breakdown. For general competitive overviews, the summary metrics are sufficient. Use fieldmask to control which competitor fields are returned.
+
+**Recommended fieldmask (Maps scans):** "date,keyword,grid_size,radius,businesses.*.name,businesses.*.place_id,businesses.*.arp,businesses.*.atrp,businesses.*.solv,businesses.*.reviews,businesses.*.rating,businesses.*.lat,businesses.*.lng"
+
+**Recommended fieldmask (AI scans):** swap \`businesses.*.solv\` for \`businesses.*.saiv\`. AI-platform competitor reports return the same overall shape but per-competitor metadata is leaner (no rating/reviews/phone/categories) and the visibility metric is \`saiv\` instead of \`solv\`. The businesses array may also be empty for AI scans where no structured competitors were cited.
+
+Available for all platform types. Get the report_key from getLocalFalconCompetitorReports.`,
     {
       reportKey: z.string().describe("The report_key of the Competitor Report you wish to retrieve."),
       fieldmask: z.string().nullish().describe("Comma-separated list of fields to return. Use dot notation for nested fields (e.g., 'location.name'). Use wildcards for arrays (e.g., 'scans.*.arp'). Omit to return all fields."),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist"
   },
-  "include": ["*.ts"]
+  "include": ["*.ts"],
+  "exclude": ["**/*.test.ts", "node_modules", "dist"]
 }


### PR DESCRIPTION
# v1.4.0 — Reviewer compliance + production bug fix

This release addresses feedback from our external connector review process plus improvements surfaced during a related audit. It's a coordinated MCP-only release: no API or documentation changes ship alongside it. Everything is additive — existing tool inputs continue to work, existing tool return shapes gain new optional fields (`_warnings`, `report_key` on scan submission), no field names are removed or renamed.

## Production bug fixed

**Silent failures on long-running scan submissions are eliminated.** A `.includes('timeout')` check in the scan-submission error path was missing the actual error string `"Request timed out"` (two words, not one). The effect was that scans that took longer than 15 seconds to submit — common on larger grid sizes or under normal queue load — surfaced as tool errors to the agent instead of the intended success-with-processing response. The agent had no signal that the scan was actually running. This bug was surfaced by a comprehensive audit triggered by external review feedback; the fix is a one-line regex change, shipped isolated as the first commit in this release so it can be cherry-picked to a hotfix if needed.

## New capabilities

**Eager scan submission now returns `report_key` immediately.** The MCP now sends `eager=1` to LF.api's run-scan endpoint, which shortens the server's completion-wait from 360 seconds to 20 seconds and always populates `data.report_key` in the response — even when the scan hasn't finished processing. Before: agents submitting a scan had to poll `listLocalFalconScanReports` repeatedly to discover the new report's key. After: the submission response carries the key directly, and the agent can immediately call `getLocalFalconReport` to check status. The MCP timeout was raised from 15s to 25s to keep a 5s margin over the server's 20s eager budget — this ensures the `report_key` is captured rather than lost to a network timeout fallback.

**`_warnings` array surfaces unrecognized fieldmask entries.** When a fieldmask request includes paths that don't resolve in the response (e.g., a typo, a stale field name, a guess), the MCP tool response now includes a `_warnings` array listing the unrecognized entries as human-readable messages: `"Unknown field in fieldmask: <path>"`. Previously, such entries were silently dropped and the agent had no signal that its fieldmask was partially ignored. This surfaces information the API has been emitting via the response wrapper for some time; the MCP was unwrapping and discarding it.

**Richer 4xx error messages.** MCP errors on 4xx responses now include specific guidance per status code. A 404 becomes `"Report not found. The reportKey may not exist, may have expired, or may belong to a different account. Verify the reportKey is correct."` A 403 becomes `"Access denied. This resource belongs to a different account, or the API key / OAuth token lacks permission."` 401 and 429 have similarly specific messages. Non-JSON error bodies (some endpoints return plain text) are handled with a generic prefix and passthrough. The underlying server message is preserved as a `(Server: ...)` suffix on every case.

## Input validation tightened

9 tool parameters that take URL-path identifiers now validate their inputs at the Zod schema layer before any network call:

- `getLocalFalconReport.reportKey` and 6 other `reportKey` parameters — require 15-character lowercase hex (e.g., `ad412d968a25a84`). Previously, empty strings silently degraded into list-endpoint calls.
- `getLocalFalconGuardReport.placeId` — requires non-empty. No regex because Place IDs span multiple formats (Google, Apple, brand).
- `getLocalFalconKnowledgeBaseArticle.articleId` — requires digits with optional `KB` prefix (`70`, `KB70`).

Malformed inputs now fail fast with a descriptive error before the API call.

## Tool documentation overhaul

Tool descriptions have been rewritten against verified response shapes, with particular attention to the new `insights.solv_competitors` metrics from recent LF API work:

- **`getLocalFalconReport`** — full rewrite. Platform-specific response shapes documented explicitly (Maps scans return `solv` and an `insights` object with `solv_competitors.{total, active}`, `osolv.{yours, top}`, `solv_distance.{yours, average}`; AI scans return `saiv` and a `sources` array; `unique_competitors` is universal on both platform groups). Size hints added for agents on context-limited models (scan reports can be 100–300KB uncompressed). `ai_analysis.summary` called out as a surgical fieldmask alternative to the whole `ai_analysis` object (which is a structured `{summary, problem, success, vulnerable, competitors, citations}` object, not an HTML string).
- **`getLocalFalconCampaignReport`** — removes `arp_move`, `atrp_move`, `solv_move` from the recommended fieldmask. These delta fields appear on `listLocalFalconCampaignReports` items but not on this single-get endpoint. Documented the distinction inline.
- **`getLocalFalconCompetitorReport`** — recommended fieldmask split into Maps and AI variants (swap `businesses.*.solv` for `businesses.*.saiv` on AI). Documented the leaner per-competitor shape and possible empty-businesses case on AI scans.
- **`listLocalFalconReviewsAnalysisReports`** — corrected recommended fieldmask to reference `review_date` (the shipped field name) instead of `date`.
- **`getLocalFalconTrendReport`, `getLocalFalconLocationReport`, `getLocalFalconKeywordReport`, `getLocalFalconReviewsAnalysisReport`** — added stronger fieldmask-recommendation language with size rationale (e.g., reviews analysis reports can exceed 100KB given sentiment/topic breakdowns across up to 1M reviews).
- **Shared fieldmask parameter description (19 tools)** — replaced misleading "wildcards for arrays" example with explicit guidance covering the three cases: arrays (`scans.*.arp`), dicts of objects (`places.*.solv`), and dicts of scalars (`rankings.by_arp` — request by path alone; wildcard can't descend into scalar values). Folds in the "strongly recommended on every call" signal.
- **Interpretation guidance** — removed bullet points referencing fields that don't exist at any path (`Opportunity SoLV`, `Competition SoLV` as top-level metrics). Replaced with guidance that uses the real shipped `insights.osolv.{yours, top}` and `insights.solv_competitors.{total, active}`.

## Acknowledgments

Thanks to the Local Falcon API team for the recent API-side work this release surfaces through the MCP: `field_mask_warnings` (enables the new `_warnings` array), structured 4xx status codes (enables the richer error messages), and the `insights.solv_competitors` metrics (reflected in the new tool description recipes).

## Rollback plan

If v1.4.0 surfaces production issues, rollback is: (1) `npm unpublish @local-falcon/mcp@1.4.0 --force` to remove from registry, (2) `git revert` the merge commit on main to restore v1.3.1 code, (3) redeploy. Render auto-deploys on main push. Total rollback time ~5 minutes. No data migration, no schema changes, no external dependency changes — this is a pure MCP code release.

## Full commit list

- `fix: handle "timed out" and "timeout" error message variants in runLocalFalconScan`
- `feat: adopt eager scan submission to surface report_key immediately`
- `feat: preserve API wrapper siblings — surface _warnings and richer 4xx errors`
- `fix: align tool descriptions with actual API response shapes`
- `feat: tighten input schemas — fieldmask help-text + URL-path ID validation`
- `docs: strengthen fieldmask recommendation with size-aware guidance`
