### PR TITLE
fix(http): return 200 for sessionless GET /mcp (v1.4.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-falcon",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "AI visibility and local search intelligence platform",
   "author": {
     "name": "Local Falcon",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 This is the **Local Falcon MCP Server** (`@local-falcon/mcp`), a Model Context Protocol server that wraps the [Local Falcon API](https://docs.localfalcon.com). It enables AI agents to run geo-grid rank tracking scans, retrieve reports, manage campaigns, monitor Google Business Profiles, and analyze competitive positioning across Google Maps, Apple Maps, and AI search platforms.
 
 **Package:** [`@local-falcon/mcp`](https://www.npmjs.com/package/@local-falcon/mcp) (npm)
-**Version:** 1.4.3
+**Version:** 1.4.4
 **License:** MIT
 **Runtime:** Node.js 18+
 **Language:** TypeScript (strict mode)

--- a/index.ts
+++ b/index.ts
@@ -844,10 +844,26 @@ const setupHTTPRoutes = (app: Application, sessionManager: SessionManager): void
     });
   });
 
+  // Sessionless GET /mcp — returns 200 with server info when no mcp-session-id header.
+  // A 410 to a sessionless request is semantically wrong: nothing is "expired"
+  // because nothing was started. Requests WITH the header fall through to
+  // mcpGetHandler, which keeps the 410 for invalid sessions per MCP spec.
+  const sessionlessMcpInfoHandler: RequestHandler = (req, res, next) => {
+    if (req.headers['mcp-session-id']) {
+      return next();
+    }
+    res.status(200).json({
+      name: "Local Falcon MCP Server",
+      status: "ok",
+      message: "MCP endpoint active. Session required - connect via MCP client.",
+      documentation: "https://localfalcon.com/mcp",
+    });
+  };
+
   // Mount on both /mcp and / so clients can connect to either path.
   // Root path mounting ensures OAuth discovery works when the server URL has no path.
   app.post('/mcp', mcpRateLimiter, conditionalBearerAuth, mcpHandler);
-  app.get('/mcp', mcpGetHandler);
+  app.get('/mcp', sessionlessMcpInfoHandler, mcpGetHandler);
   app.delete('/mcp', mcpDeleteHandler);
 
   app.post('/', mcpRateLimiter, conditionalBearerAuth, mcpHandler);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "local-falcon-mcp",
   "display_name": "Local Falcon",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Monitor and improve visibility across AI search platforms (ChatGPT, Gemini, Grok, Google AI Overviews, AI Mode) and in local search (Google Maps, Apple Maps) with 37 tools for AI visibility tracking, geo-grid rank analysis, competitor intelligence, campaign management, and Google Business Profile monitoring.",
   "long_description": "An MCP server for the Local Falcon AI Visibility and local SEO platform. Connect Claude to your Local Falcon account to track how businesses appear across AI search results and traditional map platforms.\n\nCapabilities include running geo-grid scans that check visibility from dozens of surrounding coordinates simultaneously, retrieving scan reports with AI-powered analysis, tracking visibility trends over time, managing scheduled campaigns across multiple locations and keywords, monitoring Google Business Profiles for unwanted changes with Falcon Guard, analyzing reviews with sentiment and topic breakdowns, and researching competitors to identify strategic opportunities.\n\nSupported platforms: Google Maps, Apple Maps, Google AI Overviews, Google AI Mode, ChatGPT, Gemini, and Grok.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@local-falcon/mcp",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@local-falcon/mcp",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@local-falcon/mcp",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "An MCP server for the Local Falcon API.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Summary

- **Bug:** `GET /mcp` with no `mcp-session-id` header was returning **410 Gone**.
  Automated connectivity probes and bare-GET health checks interpret 410 as
  "permanently gone — stop trying," which is wrong for a request that never
  started a session.
- **Fix:** Gate `app.get('/mcp', ...)` with a small middleware that returns
  **200 + JSON server info** when the header is absent. Requests *with* the
  header fall through to `mcpGetHandler` unchanged, so the 410 still fires
  for invalid/expired sessions per MCP spec.
- **Pattern:** Mirrors the existing root `GET /` handler at `index.ts:834`.
- **Version:** Bumped `1.4.3 → 1.4.4` across `package.json`, `manifest.json`,
  `.claude-plugin/plugin.json`, `package-lock.json`, and `CLAUDE.md`.

## Behavior matrix

| Request | Response |
|---|---|
| `GET /mcp` (no session header) | **200** + info JSON (new) |
| `GET /mcp` with `mcp-session-id: <invalid>` | **410** session_expired (unchanged) |
| `GET /mcp` with `mcp-session-id: <valid>` | SSE stream (unchanged) |
| `GET /` (no session header) | **200** + info JSON (unchanged) |

## Test plan

After merge → tag → release, verify on production:

- [ ] `curl -s -o /dev/null -w "%{http_code}" https://mcp.localfalcon.com/mcp` → **200**
- [ ] `curl -s -o /dev/null -w "%{http_code}" -H "mcp-session-id: fake123" https://mcp.localfalcon.com/mcp` → **410**
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://mcp.localfalcon.com` → **200**
- [ ] Connect from an MCP client → tools work normally with a real session

Local checks already done:
- [x] `bun test` — 33/33 pass
- [x] `npx tsc --noEmit` — clean

## Release process (post-merge)

1. Merge this PR to `main`
2. `git tag v1.4.4 && git push origin v1.4.4`
3. Create GitHub Release from tag `v1.4.4` → `.github/workflows/npm-publish.yml` auto-publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)