### PR TITLE
ci(npm-publish): migrate to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,5 +30,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces the long-lived `NPM_TOKEN` repo secret with short-lived **OIDC tokens** minted by GitHub Actions at workflow run-time. Eliminates publish-token rotation pain entirely and resists the class of supply-chain attacks that exfiltrate write tokens.

## Workflow diff

```diff
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       ...
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

Two changes:
1. Add `id-token: write` permission so the runner can request an OIDC token
2. Drop `NODE_AUTH_TOKEN` env — npm CLI ≥ 11.5 automatically detects the OIDC context and uses it instead of a static token

`actions/setup-node@v4` with `registry-url: https://registry.npmjs.org` already wires up the publish registry correctly; nothing else needs to change.

## Required npmjs.com configuration

This PR will only succeed in publishing if a **Trusted Publisher** is configured on the package side at https://www.npmjs.com/package/@local-falcon/mcp/access:

| Field | Value |
|---|---|
| Publisher | GitHub Actions |
| Organization / user | `local-falcon` |
| Repository | `mcp` |
| Workflow filename | `npm-publish.yml` |
| Environment name | *(leave blank)* |

Once the publish succeeds, the `NPM_TOKEN` repo secret can be deleted — it's no longer used.

## Test plan

- [x] YAML syntactically valid
- [ ] Trusted Publisher configured on npmjs.com side
- [ ] After merge, re-issue the v1.4.4 release → workflow fires with OIDC → publishes to npm registry
- [ ] Verify `npm view @local-falcon/mcp version` shows `1.4.4`
- [ ] Delete `NPM_TOKEN` repo secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)