### PR TITLE
ci(npm-publish): upgrade npm to 11.5+ for OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for Trusted Publishing (OIDC requires >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Fix follow-up to #15. OIDC token exchange in npm CLI requires >= 11.5.1; Node 22's bundled npm 10.x doesn't recognize the OIDC env vars and falls back to the empty NODE_AUTH_TOKEN from setup-node's generated .npmrc, producing a 404. Adds an explicit npm upgrade step before publish.