### PR TITLE
ci(npm-publish): use Node 24 for native npm 11.5+ OIDC support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,11 +17,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm for Trusted Publishing (OIDC requires >= 11.5.1)
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Follow-up to #15 and #16. The self-upgrading `npm install -g npm@latest` step in #16 was crashing with promise-retry MODULE_NOT_FOUND during the npm 10 -> npm 11 transition. Switching the workflow to Node 24 LTS gives us npm 11.5+ natively, which is the minimum CLI that auto-detects the OIDC environment and mints a publish token without NODE_AUTH_TOKEN.